### PR TITLE
修正: DataVisualization の参照を追加

### DIFF
--- a/ShiftPlanner/ShiftPlanner.csproj
+++ b/ShiftPlanner/ShiftPlanner.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Windows.Forms.DataVisualization" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## 概要
- `ShiftAnalyzer.cs` で `System.Windows.Forms.DataVisualization.Charting` を使用しているが、`csproj` に参照が不足していたためビルドエラーが発生していた
- `ShiftPlanner.csproj` に `System.Windows.Forms.DataVisualization` 参照を追加

## テスト
- テスト実行環境がないためビルドは未実施
