### PR TITLE
DataContractJsonSerializer用参照追加

### DIFF
--- a/ShiftPlanner/ShiftPlanner.csproj
+++ b/ShiftPlanner/ShiftPlanner.csproj
@@ -48,6 +48,8 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Forms.DataVisualization" />
+    <!-- Json シリアライズ用 -->
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- `System.Runtime.Serialization` を参照に追加し、`DataContractJsonSerializer` 使用時のビルドエラーを修正しました。

## Testing
- `dotnet build` *(失敗: `dotnet` コマンドが見つかりません)*

------
https://chatgpt.com/codex/tasks/task_e_683c30d91a3483338bba62c7503d0903