### PR TITLE
データ契約属性の追加

### DIFF
--- a/ShiftPlanner/Member.cs
+++ b/ShiftPlanner/Member.cs
@@ -1,26 +1,44 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace ShiftPlanner
 {
+    /// <summary>
+    /// 従業員情報を表します。
+    /// </summary>
+    [DataContract]
     public class Member
     {
+        [DataMember]
         public int Id { get; set; }
-        public string Name { get; set; }
-        public List<DayOfWeek> AvailableDays { get; set; }
+
+        [DataMember]
+        public string Name { get; set; } = string.Empty;
+
+        [DataMember]
+        public List<DayOfWeek> AvailableDays { get; set; } = new List<DayOfWeek>();
+
+        [DataMember]
         public TimeSpan AvailableFrom { get; set; }
+
+        [DataMember]
         public TimeSpan AvailableTo { get; set; }
-        public List<string> Skills { get; set; }
+
+        [DataMember]
+        public List<string> Skills { get; set; } = new List<string>();
 
         /// <summary>
         /// 希望休の日付一覧。
         /// </summary>
-        public List<DateTime> DesiredHolidays { get; set; }
+        [DataMember]
+        public List<DateTime> DesiredHolidays { get; set; } = new List<DateTime>();
 
         /// <summary>
         /// 勤務時間や連続勤務上限などの制約設定。
         /// </summary>
-        public ShiftConstraints Constraints { get; set; }
+        [DataMember]
+        public ShiftConstraints Constraints { get; set; } = new ShiftConstraints();
     }
 }

--- a/ShiftPlanner/ShiftAssignment.cs
+++ b/ShiftPlanner/ShiftAssignment.cs
@@ -1,15 +1,31 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace ShiftPlanner
 {
+    /// <summary>
+    /// 各日付の割り当て結果を表します。
+    /// </summary>
+    [DataContract]
     public class ShiftAssignment
     {
+        [DataMember]
         public DateTime Date { get; set; }
-        public string ShiftType { get; set; }
+
+        [DataMember]
+        public string ShiftType { get; set; } = string.Empty;
+
+        [DataMember]
         public int RequiredNumber { get; set; }
+
+        [DataMember]
         public List<Member> AssignedMembers { get; set; } = new List<Member>();
+
+        // 割当人数不足判定
         public bool Shortage => AssignedMembers.Count < RequiredNumber;
+
+        // 割当人数過剰判定
         public bool Excess => AssignedMembers.Count > RequiredNumber;
     }
 }

--- a/ShiftPlanner/ShiftConstraints.cs
+++ b/ShiftPlanner/ShiftConstraints.cs
@@ -1,25 +1,30 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace ShiftPlanner
 {
     /// <summary>
     /// 各従業員に適用される勤務条件を表します。
     /// </summary>
+    [DataContract]
     public class ShiftConstraints
     {
         /// <summary>
         /// 1週間あたりの最小勤務時間(時間単位)。
         /// </summary>
+        [DataMember]
         public double MinWeeklyHours { get; set; }
 
         /// <summary>
         /// 1週間あたりの最大勤務時間(時間単位)。
         /// </summary>
+        [DataMember]
         public double MaxWeeklyHours { get; set; }
 
         /// <summary>
         /// 連続勤務可能日数の上限。
         /// </summary>
+        [DataMember]
         public int MaxConsecutiveDays { get; set; }
     }
 }

--- a/ShiftPlanner/ShiftFrame.cs
+++ b/ShiftPlanner/ShiftFrame.cs
@@ -1,14 +1,28 @@
 
 using System;
+using System.Runtime.Serialization;
 
 namespace ShiftPlanner
 {
+    /// <summary>
+    /// 1つのシフト枠を表します。
+    /// </summary>
+    [DataContract]
     public class ShiftFrame
     {
+        [DataMember]
         public DateTime Date { get; set; }
-        public string ShiftType { get; set; }
+
+        [DataMember]
+        public string ShiftType { get; set; } = string.Empty;
+
+        [DataMember]
         public TimeSpan ShiftStart { get; set; }
+
+        [DataMember]
         public TimeSpan ShiftEnd { get; set; }
+
+        [DataMember]
         public int RequiredNumber { get; set; }
     }
 }


### PR DESCRIPTION
## 変更内容
- `Member`, `ShiftConstraints`, `ShiftFrame`, `ShiftAssignment` クラスへ `[DataContract]` と `[DataMember]` を付与
- 各リスト・文字列プロパティに初期化子を追加し null 参照を防止
- `ShiftAssignment` などのコメントを追加し可読性を向上

## 動作確認
- `dotnet` コマンドが存在しないためビルドは未実施
- 既存の `LoadMembers`/`SaveMembers` で `DataContractJsonSerializer` を利用していることを確認済み

------
https://chatgpt.com/codex/tasks/task_e_683e7116dd988333831b4758b622bac9