### PR TITLE
グラフ表示の分析タブ追加

### DIFF
--- a/ShiftPlanner/ShiftAnalyzer.cs
+++ b/ShiftPlanner/ShiftAnalyzer.cs
@@ -31,6 +31,26 @@ namespace ShiftPlanner
         }
 
         /// <summary>
+        /// 指定した月のシフトタイプごとの件数を取得します。
+        /// </summary>
+        /// <param name="shifts">対象シフト一覧</param>
+        /// <param name="year">年</param>
+        /// <param name="month">月</param>
+        /// <returns>シフトタイプと件数の辞書</returns>
+        public static Dictionary<string, int> GetShiftTypeDistribution(IEnumerable<ShiftFrame> shifts, int year, int month)
+        {
+            if (shifts == null)
+            {
+                return new Dictionary<string, int>();
+            }
+
+            return shifts
+                .Where(s => s.Date.Year == year && s.Date.Month == month)
+                .GroupBy(s => s.ShiftType ?? string.Empty)
+                .ToDictionary(g => g.Key, g => g.Count());
+        }
+
+        /// <summary>
         /// シフトタイプごとの分布を円グラフとして画像出力します。
         /// </summary>
         public static void ExportDistributionChart(IEnumerable<ShiftFrame> shifts, string path)


### PR DESCRIPTION
## 概要
- ShiftAnalyzer にシフトタイプ分布取得メソッドを追加
- MainForm に分析用タブを新設し、月間総労働時間とシフトタイプ分布を表示
- グラフは `System.Windows.Forms.DataVisualization.Charting` を利用

## テスト
- `dotnet build` を試みましたが `dotnet` コマンドが存在せずビルドできませんでした

------
https://chatgpt.com/codex/tasks/task_e_683fb476adcc83339912f1fd6efa2121