### PR TITLE
シフト情報の保存処理追加

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -158,12 +158,96 @@ namespace ShiftPlanner
             }
         }
 
+        /// <summary>
+        /// シフトフレームを読み込みます。
+        /// </summary>
+        private void LoadFrames()
+        {
+            if (File.Exists(frameFilePath))
+            {
+                try
+                {
+                    var serializer = new DataContractJsonSerializer(typeof(List<ShiftFrame>));
+                    using (var stream = File.OpenRead(frameFilePath))
+                    {
+                        shiftFrames = (List<ShiftFrame>)serializer.ReadObject(stream);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show($"シフトフレームの読み込みに失敗しました: {ex.Message}");
+                    shiftFrames = new List<ShiftFrame>();
+                }
+            }
+        }
+
+        /// <summary>
+        /// シフトフレームを保存します。
+        /// </summary>
+        private void SaveFrames()
+        {
+            try
+            {
+                var serializer = new DataContractJsonSerializer(typeof(List<ShiftFrame>));
+                using (var stream = File.Create(frameFilePath))
+                {
+                    serializer.WriteObject(stream, shiftFrames);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"シフトフレームの保存に失敗しました: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// 割り当て結果を読み込みます。
+        /// </summary>
+        private void LoadAssignments()
+        {
+            if (File.Exists(assignmentFilePath))
+            {
+                try
+                {
+                    var serializer = new DataContractJsonSerializer(typeof(List<ShiftAssignment>));
+                    using (var stream = File.OpenRead(assignmentFilePath))
+                    {
+                        assignments = (List<ShiftAssignment>)serializer.ReadObject(stream);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show($"割り当て結果の読み込みに失敗しました: {ex.Message}");
+                    assignments = new List<ShiftAssignment>();
+                }
+            }
+        }
+
+        /// <summary>
+        /// 割り当て結果を保存します。
+        /// </summary>
+        private void SaveAssignments()
+        {
+            try
+            {
+                var serializer = new DataContractJsonSerializer(typeof(List<ShiftAssignment>));
+                using (var stream = File.Create(assignmentFilePath))
+                {
+                    serializer.WriteObject(stream, assignments ?? new List<ShiftAssignment>());
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"割り当て結果の保存に失敗しました: {ex.Message}");
+            }
+        }
+
         private void InitializeData()
         {
             LoadMembers();
-
+            LoadFrames();
             LoadRequests();
-
+            LoadAssignments();
 
             if (members.Count == 0)
             {
@@ -194,36 +278,42 @@ namespace ShiftPlanner
                 });
             }
 
-
-            // シフトフレーム例
-            shiftFrames.Add(new ShiftFrame
+            // シフトフレームが無い場合は例としていくつか作成
+            if (shiftFrames.Count == 0)
             {
-                Date = DateTime.Today.AddDays(1),
-                ShiftType = "早番",
-                ShiftStart = TimeSpan.FromHours(9),
-                ShiftEnd = TimeSpan.FromHours(17),
-                RequiredNumber = 2
-            });
-            shiftFrames.Add(new ShiftFrame
-            {
-                Date = DateTime.Today.AddDays(2),
-                ShiftType = "早番",
-                ShiftStart = TimeSpan.FromHours(9),
-                ShiftEnd = TimeSpan.FromHours(17),
-                RequiredNumber = 1
-            });
-            // 例として 3 日目の遅番を追加
-            shiftFrames.Add(new ShiftFrame
-            {
-                Date = DateTime.Today.AddDays(3),
-                ShiftType = "遅番",
-                ShiftStart = TimeSpan.FromHours(13),
-                ShiftEnd = TimeSpan.FromHours(21),
-                RequiredNumber = 2
-            });
+                shiftFrames.Add(new ShiftFrame
+                {
+                    Date = DateTime.Today.AddDays(1),
+                    ShiftType = "早番",
+                    ShiftStart = TimeSpan.FromHours(9),
+                    ShiftEnd = TimeSpan.FromHours(17),
+                    RequiredNumber = 2
+                });
+                shiftFrames.Add(new ShiftFrame
+                {
+                    Date = DateTime.Today.AddDays(2),
+                    ShiftType = "早番",
+                    ShiftStart = TimeSpan.FromHours(9),
+                    ShiftEnd = TimeSpan.FromHours(17),
+                    RequiredNumber = 1
+                });
+                shiftFrames.Add(new ShiftFrame
+                {
+                    Date = DateTime.Today.AddDays(3),
+                    ShiftType = "遅番",
+                    ShiftStart = TimeSpan.FromHours(13),
+                    ShiftEnd = TimeSpan.FromHours(21),
+                    RequiredNumber = 2
+                });
+                SaveFrames();
+            }
 
-            assignments = ShiftGenerator.GenerateBaseShift(shiftFrames, members, shiftRequests);
-
+            // 割り当て結果が無い場合は自動生成
+            if (assignments.Count == 0)
+            {
+                assignments = ShiftGenerator.GenerateBaseShift(shiftFrames, members, shiftRequests);
+                SaveAssignments();
+            }
         }
 
         private void SetupDataGridView()
@@ -537,6 +627,8 @@ namespace ShiftPlanner
         {
             SaveMembers();
             SaveRequests();
+            SaveFrames();
+            SaveAssignments();
             base.OnFormClosing(e);
         }
 


### PR DESCRIPTION
## 概要
シフトフレームおよび割り当て結果の読み込み・保存処理を実装しました。またアプリ終了時に各データを保存するよう更新しました。

## 主な変更点
- `LoadFrames`/`SaveFrames`、`LoadAssignments`/`SaveAssignments` を追加
- 初期化処理 `InitializeData` で各ファイルから読み込むよう変更
- フレーム・割り当てが無い場合はサンプルデータ生成後に保存
- アプリ終了時 `OnFormClosing` でフレームと割り当て結果も保存

## テスト
- `dotnet build` を実行しようとしましたが、環境に `dotnet` コマンドが無くビルドできませんでした

------
https://chatgpt.com/codex/tasks/task_e_683fd141b4308333ba927ec70e796127