### PR TITLE
UI 定義の修正と C# 8.0 対応

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -26,7 +26,15 @@ namespace ShiftPlanner
         private Button btnRemoveRequest;
         private Button btnRefreshShift;
         private DateTimePicker dtpMonth;
-        private TabPage tabPage3;
+        // CSV、PDF出力ボタン
+        private Button btnExportCsv;
+        private Button btnExportPdf;
+        // メニュー関連
+        private MenuStrip menuStrip1;
+        private ToolStripMenuItem menuFile;
+        private ToolStripMenuItem menuExportCsv;
+        private ToolStripMenuItem menuExportPdf;
+        // tabPage3 は上で宣言済みのため削除
         private DateTimePicker dtp分析月;
         private Label lbl総労働時間;
         private System.Windows.Forms.DataVisualization.Charting.Chart chartシフト分布;
@@ -751,7 +759,12 @@ namespace ShiftPlanner
             this.btnRemoveRequest = new System.Windows.Forms.Button();
             this.btnRefreshShift = new System.Windows.Forms.Button();
             this.dtpMonth = new System.Windows.Forms.DateTimePicker();
-            this.tabPage3 = new System.Windows.Forms.TabPage();
+            this.btnExportCsv = new System.Windows.Forms.Button();
+            this.btnExportPdf = new System.Windows.Forms.Button();
+            this.menuStrip1 = new System.Windows.Forms.MenuStrip();
+            this.menuFile = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuExportCsv = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuExportPdf = new System.Windows.Forms.ToolStripMenuItem();
             this.dtp分析月 = new System.Windows.Forms.DateTimePicker();
             this.lbl総労働時間 = new System.Windows.Forms.Label();
             this.chartシフト分布 = new System.Windows.Forms.DataVisualization.Charting.Chart();

--- a/ShiftPlanner/ShiftPlanner.csproj
+++ b/ShiftPlanner/ShiftPlanner.csproj
@@ -13,6 +13,9 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
+    <!-- C# 8.0 機能を利用するため言語バージョンを指定 -->
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
## 変更内容
- MainForm で不足していたメニューやエクスポートボタンのフィールドを追加
- 重複していた `tabPage3` フィールドを削除
- csproj に `LangVersion` と `Nullable` 設定を追加し、C# 8.0 を利用可能に

## テスト
- `dotnet` コマンドが利用できずビルドは未実行


------
https://chatgpt.com/codex/tasks/task_e_683fd6604ce883339e79cb695827172e