### PR TITLE
シフト表ヘッダーの幅調整

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -379,6 +379,8 @@ namespace ShiftPlanner
 
             dtShift.AutoGenerateColumns = true;
             dtShift.DataSource = table;
+            dtShift.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.None;
+            dtShift.ColumnHeadersDefaultCellStyle.WrapMode = DataGridViewTriState.False;
 
             for (int day = 1; day <= daysInMonth; day++)
             {
@@ -387,7 +389,11 @@ namespace ShiftPlanner
                 var col = dtShift.Columns[header];
                 if (col != null)
                 {
-                    col.Width = 45;
+                    col.AutoSizeMode = DataGridViewAutoSizeColumnMode.None;
+                    col.HeaderCell.Style.WrapMode = DataGridViewTriState.False;
+                    col.HeaderCell.Style.Alignment = DataGridViewContentAlignment.MiddleCenter;
+                    col.DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleCenter;
+                    col.Width = 40;
                     if (date.DayOfWeek == DayOfWeek.Saturday || date.DayOfWeek == DayOfWeek.Sunday)
                     {
                         col.DefaultCellStyle.BackColor = Color.LightYellow;
@@ -436,7 +442,7 @@ namespace ShiftPlanner
                 MessageBox.Show($"セルの着色中にエラーが発生しました: {ex.Message}");
             }
 
-            dtShift.AutoResizeColumns();
+            // 自動リサイズは行わず固定幅を維持
         }
 
         /// <summary>


### PR DESCRIPTION
## 変更内容
- DataGridView の列ヘッダーが2行に折り返されないよう設定を追加
- 列幅を40pxに固定し中央寄せ表示へ変更
- 自動列幅調整を行わないよう修正

## テスト
- `dotnet build` を試みましたが、環境に `dotnet` コマンドがなく実行できませんでした

------
https://chatgpt.com/codex/tasks/task_e_6840f3a230108333904faa828dc7b8b4