### PR TITLE
必要人数リセット処理の追加

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -219,6 +219,27 @@ namespace ShiftPlanner
         }
 
         /// <summary>
+        /// すべてのシフトフレームの必要人数をリセットします。
+        /// </summary>
+        private void ResetRequiredNumbers()
+        {
+            if (shiftFrames == null)
+            {
+                return; // null 安全対策
+            }
+
+            foreach (var frame in shiftFrames)
+            {
+                if (frame != null)
+                {
+                    frame.RequiredNumber = 0;
+                }
+            }
+
+            SaveFrames();
+        }
+
+        /// <summary>
         /// 割り当て結果を読み込みます。
         /// </summary>
         private void LoadAssignments()
@@ -841,6 +862,9 @@ namespace ShiftPlanner
 
                 // 手入力分を優先して反映
                 ApplyManualAssignments(manual);
+
+                // 必要人数をリセット
+                ResetRequiredNumbers();
 
                 SetupDataGridView();
                 SaveAssignments();


### PR DESCRIPTION
## 変更内容
- MainForm に必要人数を0に戻す `ResetRequiredNumbers` メソッドを追加
- シフト更新処理(`btnRefreshShift_Click`)で自動割当後に上記メソッドを呼び出すよう変更
- 更新後に `SetupDataGridView` を実行して表示をリフレッシュ

## テスト
- `dotnet build` を試行したが `dotnet: command not found` となり実行できず

------
https://chatgpt.com/codex/tasks/task_e_68410ad9dc808333b46720622df6cdf3