### PR TITLE
グリッドのソートを無効化

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -466,6 +466,9 @@ namespace ShiftPlanner
                 }
             }
 
+            // すべての列をソート不可に設定
+            SetColumnsNotSortable(dtShift);
+
             // 割当人数行の不足・過剰を色分け
             try
             {
@@ -536,6 +539,26 @@ namespace ShiftPlanner
             }
 
             return string.Empty;
+        }
+
+        /// <summary>
+        /// 指定したグリッドの列をすべてソート不可に設定します。
+        /// </summary>
+        /// <param name="grid">対象のDataGridView</param>
+        private static void SetColumnsNotSortable(DataGridView grid)
+        {
+            if (grid == null || grid.Columns == null)
+            {
+                return; // null 安全対策
+            }
+
+            foreach (DataGridViewColumn column in grid.Columns)
+            {
+                if (column != null)
+                {
+                    column.SortMode = DataGridViewColumnSortMode.NotSortable;
+                }
+            }
         }
 
         /// <summary>
@@ -754,6 +777,9 @@ namespace ShiftPlanner
                             break;
                     }
                 }
+
+                // 列をソート不可に設定
+                SetColumnsNotSortable(dtMembers);
             }
             catch (Exception ex)
             {
@@ -827,6 +853,9 @@ namespace ShiftPlanner
                             break;
                     }
                 }
+
+                // 列をソート不可に設定
+                SetColumnsNotSortable(dtRequests);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## 変更内容
- DataGridView の列に対し `NotSortable` を設定するヘルパー `SetColumnsNotSortable` を追加
- シフト表・メンバー一覧・希望休一覧の各グリッドで上記ヘルパーを呼び出し、列のソート機能を無効化

## テスト
- `dotnet` コマンドが存在しないためビルド実行はできませんでした

------
https://chatgpt.com/codex/tasks/task_e_6841453968608333ae48a159dbe2f62d