### PR TITLE
希望タブの休み希望デフォルト対応

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -915,7 +915,8 @@ namespace ShiftPlanner
 
         private void btnAddRequest_Click(object sender, EventArgs e)
         {
-            using (var form = new ShiftRequestForm(members))
+            // 休み希望をデフォルトでチェックした状態でフォームを表示
+            using (var form = new ShiftRequestForm(members, true))
             {
                 if (form.ShowDialog() == DialogResult.OK && form.ShiftRequest != null)
                 {

--- a/ShiftPlanner/ShiftRequestForm.cs
+++ b/ShiftPlanner/ShiftRequestForm.cs
@@ -16,13 +16,31 @@ namespace ShiftPlanner
 
         public ShiftRequest? ShiftRequest { get; private set; }
 
-        public ShiftRequestForm(List<Member> members)
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="members">メンバー一覧</param>
+        /// <param name="holidayChecked">休み希望チェックの初期値</param>
+        public ShiftRequestForm(List<Member> members, bool holidayChecked = false)
         {
             this.members = members ?? new List<Member>();
             InitializeComponent();
-            cmbMember.DataSource = this.members;
-            cmbMember.DisplayMember = "Name";
-            cmbMember.ValueMember = "Id";
+
+            try
+            {
+                // メンバー情報をコンボボックスへ設定
+                cmbMember.DataSource = this.members;
+                cmbMember.DisplayMember = "Name";
+                cmbMember.ValueMember = "Id";
+            }
+            catch (Exception ex)
+            {
+                // 例外が発生してもアプリが終了しないよう通知のみ
+                MessageBox.Show($"メンバー情報の読込に失敗しました: {ex.Message}");
+            }
+
+            // 休み希望チェックボックスの初期状態を設定
+            chkHoliday.Checked = holidayChecked;
         }
 
         // このメソッドの内容は ShiftRequestForm.Designer.cs に移動しました。


### PR DESCRIPTION
## 変更内容
- `ShiftRequestForm` のコンストラクタに休み希望チェックの初期値を指定できる引数を追加
- `MainForm` から希望登録フォームを開く際、休み希望が初期状態でオンになるよう変更
- コンボボックス設定処理にエラーハンドリングを追加

## 動作確認
- `dotnet` コマンドが利用できないためビルド確認は行えていません


------
https://chatgpt.com/codex/tasks/task_e_68453a38259c83339d5e00d1df72547c