### PR TITLE
メンバー管理をメニュー化し希望タブを改善

### DIFF
--- a/ShiftPlanner/MainForm.Designer.cs
+++ b/ShiftPlanner/MainForm.Designer.cs
@@ -34,6 +34,7 @@ namespace ShiftPlanner
         private ToolStripMenuItem menuExportPdf;
         private ToolStripMenuItem menuMaster;
         private ToolStripMenuItem menuHolidayMaster;
+        private ToolStripMenuItem menuMemberMaster;
         private DateTimePicker dtp分析月;
         private Label lbl総労働時間;
         private Chart chartシフト分布;
@@ -73,6 +74,7 @@ namespace ShiftPlanner
             this.menuExportPdf = new System.Windows.Forms.ToolStripMenuItem();
             this.menuMaster = new System.Windows.Forms.ToolStripMenuItem();
             this.menuHolidayMaster = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuMemberMaster = new System.Windows.Forms.ToolStripMenuItem();
             this.dtp分析月 = new System.Windows.Forms.DateTimePicker();
             this.lbl総労働時間 = new System.Windows.Forms.Label();
             this.chartシフト分布 = new System.Windows.Forms.DataVisualization.Charting.Chart();
@@ -133,10 +135,11 @@ namespace ShiftPlanner
             // menuMaster
             //
             // nullチェックを行い、メニュー項目が作成されている場合のみ追加
-            if (this.menuMaster != null && this.menuHolidayMaster != null)
+            if (this.menuMaster != null && this.menuHolidayMaster != null && this.menuMemberMaster != null)
             {
                 this.menuMaster.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-                this.menuHolidayMaster});
+                this.menuHolidayMaster,
+                this.menuMemberMaster});
             }
             this.menuMaster.Name = "menuMaster";
             this.menuMaster.Size = new System.Drawing.Size(61, 20);
@@ -148,9 +151,16 @@ namespace ShiftPlanner
             this.menuHolidayMaster.Size = new System.Drawing.Size(138, 22);
             this.menuHolidayMaster.Text = "祝日マスター";
             this.menuHolidayMaster.Click += new System.EventHandler(this.menuHolidayMaster_Click);
-            // 
+
+            // menuMemberMaster
+            //
+            this.menuMemberMaster.Name = "menuMemberMaster";
+            this.menuMemberMaster.Size = new System.Drawing.Size(138, 22);
+            this.menuMemberMaster.Text = "メンバーマスター";
+            this.menuMemberMaster.Click += new System.EventHandler(this.menuMemberMaster_Click);
+            //
             // tabControl1
-            // 
+            //
             this.tabControl1.Controls.Add(this.tabPage1);
             this.tabControl1.Controls.Add(this.tabPage2);
             this.tabControl1.Controls.Add(this.tabPage3);

--- a/ShiftPlanner/MemberMasterForm.Designer.cs
+++ b/ShiftPlanner/MemberMasterForm.Designer.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Windows.Forms;
+
+namespace ShiftPlanner
+{
+    public partial class MemberMasterForm
+    {
+        private System.ComponentModel.IContainer? components = null;
+        private DataGridView dtMembers;
+        private Button btnAdd;
+        private Button btnRemove;
+        private Button btnOk;
+        private Button btnCancel;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.dtMembers = new DataGridView();
+            this.btnAdd = new Button();
+            this.btnRemove = new Button();
+            this.btnOk = new Button();
+            this.btnCancel = new Button();
+            this.SuspendLayout();
+
+            // dtMembers
+            this.dtMembers.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            this.dtMembers.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dtMembers.Location = new System.Drawing.Point(12, 41);
+            this.dtMembers.Name = "dtMembers";
+            this.dtMembers.RowTemplate.Height = 21;
+            this.dtMembers.Size = new System.Drawing.Size(560, 308);
+
+            // btnAdd
+            this.btnAdd.Location = new System.Drawing.Point(12, 12);
+            this.btnAdd.Name = "btnAdd";
+            this.btnAdd.Size = new System.Drawing.Size(75, 23);
+            this.btnAdd.Text = "追加";
+            this.btnAdd.UseVisualStyleBackColor = true;
+            this.btnAdd.Click += new EventHandler(this.BtnAdd_Click);
+
+            // btnRemove
+            this.btnRemove.Location = new System.Drawing.Point(93, 12);
+            this.btnRemove.Name = "btnRemove";
+            this.btnRemove.Size = new System.Drawing.Size(75, 23);
+            this.btnRemove.Text = "削除";
+            this.btnRemove.UseVisualStyleBackColor = true;
+            this.btnRemove.Click += new EventHandler(this.BtnRemove_Click);
+
+            // btnOk
+            this.btnOk.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            this.btnOk.Location = new System.Drawing.Point(416, 355);
+            this.btnOk.Name = "btnOk";
+            this.btnOk.Size = new System.Drawing.Size(75, 23);
+            this.btnOk.Text = "OK";
+            this.btnOk.UseVisualStyleBackColor = true;
+            this.btnOk.Click += new EventHandler(this.BtnOk_Click);
+
+            // btnCancel
+            this.btnCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            this.btnCancel.Location = new System.Drawing.Point(497, 355);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.Text = "キャンセル";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new EventHandler(this.BtnCancel_Click);
+
+            // Form
+            this.ClientSize = new System.Drawing.Size(584, 390);
+            this.Controls.Add(this.dtMembers);
+            this.Controls.Add(this.btnAdd);
+            this.Controls.Add(this.btnRemove);
+            this.Controls.Add(this.btnOk);
+            this.Controls.Add(this.btnCancel);
+            this.FormBorderStyle = FormBorderStyle.FixedDialog;
+            this.StartPosition = FormStartPosition.CenterParent;
+            this.Text = "メンバーマスター";
+
+            this.ResumeLayout(false);
+        }
+    }
+}

--- a/ShiftPlanner/MemberMasterForm.cs
+++ b/ShiftPlanner/MemberMasterForm.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace ShiftPlanner
+{
+    /// <summary>
+    /// メンバー情報を編集するフォーム
+    /// </summary>
+    public partial class MemberMasterForm : Form
+    {
+        private readonly BindingList<Member> _members;
+
+        public MemberMasterForm(List<Member> members)
+        {
+            _members = new BindingList<Member>(members ?? new List<Member>());
+            InitializeComponent();
+            dtMembers.DataSource = _members;
+            SetupMemberGrid();
+        }
+
+        /// <summary>
+        /// メンバー一覧を取得します。
+        /// </summary>
+        public List<Member> Members => _members.ToList();
+
+        private void BtnAdd_Click(object sender, EventArgs e)
+        {
+            var nextId = _members.Count > 0 ? _members.Max(m => m.Id) + 1 : 1;
+            _members.Add(new Member
+            {
+                Id = nextId,
+                Name = "新規",
+                AvailableFrom = new TimeSpan(9, 0, 0),
+                AvailableTo = new TimeSpan(18, 0, 0),
+                WorksOnSaturday = false,
+                WorksOnSunday = false
+            });
+        }
+
+        private void BtnRemove_Click(object sender, EventArgs e)
+        {
+            if (dtMembers.CurrentRow?.DataBoundItem is Member m)
+            {
+                _members.Remove(m);
+            }
+        }
+
+        private void BtnOk_Click(object sender, EventArgs e)
+        {
+            this.DialogResult = DialogResult.OK;
+        }
+
+        private void BtnCancel_Click(object sender, EventArgs e)
+        {
+            this.DialogResult = DialogResult.Cancel;
+        }
+
+        private void SetupMemberGrid()
+        {
+            dtMembers.AutoGenerateColumns = true;
+            foreach (DataGridViewColumn col in dtMembers.Columns)
+            {
+                if (col == null || string.IsNullOrEmpty(col.Name))
+                {
+                    continue;
+                }
+
+                switch (col.Name)
+                {
+                    case nameof(Member.Id):
+                        col.HeaderText = "ID";
+                        break;
+                    case nameof(Member.Name):
+                        col.HeaderText = "名前";
+                        break;
+                    case nameof(Member.AvailableDays):
+                        col.HeaderText = "勤務可能曜日";
+                        break;
+                    case nameof(Member.AvailableFrom):
+                        col.HeaderText = "開始時間";
+                        break;
+                    case nameof(Member.AvailableTo):
+                        col.HeaderText = "終了時間";
+                        break;
+                    case nameof(Member.Skills):
+                        col.HeaderText = "スキル";
+                        break;
+                    case nameof(Member.DesiredHolidays):
+                        col.HeaderText = "希望休";
+                        break;
+                    case nameof(Member.Constraints):
+                        col.Visible = false;
+                        break;
+                    case nameof(Member.WorksOnSaturday):
+                        col.HeaderText = "土曜日";
+                        break;
+                    case nameof(Member.WorksOnSunday):
+                        col.HeaderText = "日曜日";
+                        break;
+                }
+            }
+            SetColumnsNotSortable(dtMembers);
+        }
+
+        /// <summary>
+        /// 指定グリッドの列をすべてソート不可にします。
+        /// </summary>
+        private static void SetColumnsNotSortable(DataGridView grid)
+        {
+            if (grid == null || grid.Columns == null)
+            {
+                return;
+            }
+            foreach (DataGridViewColumn column in grid.Columns)
+            {
+                if (column != null)
+                {
+                    column.SortMode = DataGridViewColumnSortMode.NotSortable;
+                }
+            }
+        }
+    }
+}

--- a/ShiftPlanner/ShiftPlanner.csproj
+++ b/ShiftPlanner/ShiftPlanner.csproj
@@ -92,6 +92,12 @@
     <Compile Include="HolidayMasterForm.Designer.cs">
       <DependentUpon>HolidayMasterForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="MemberMasterForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="MemberMasterForm.Designer.cs">
+      <DependentUpon>MemberMasterForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="ShiftConstraints.cs" />
     <EmbeddedResource Include="MainForm.resx">
       <DependentUpon>MainForm.cs</DependentUpon>


### PR DESCRIPTION
## 変更内容
- メンバー編集用フォーム `MemberMasterForm` を追加
- `マスター` メニューに「メンバーマスター」を追加し、メンバータブを非表示化
- 希望タブのメンバー列を名前表示のコンボボックスに変更

## テスト
- `dotnet build` は環境に dotnet が無いため実行できず


------
https://chatgpt.com/codex/tasks/task_e_68453b5ba7648333a219d57f7c651c04