### PR TITLE
祝日マスター年別入力機能

### DIFF
--- a/ShiftPlanner/HolidayMasterForm.Designer.cs
+++ b/ShiftPlanner/HolidayMasterForm.Designer.cs
@@ -11,6 +11,8 @@ namespace ShiftPlanner
         private Button btnRemove;
         private Button btnOk;
         private Button btnCancel;
+        private Label lblYear;
+        private NumericUpDown nudYear;
 
         protected override void Dispose(bool disposing)
         {
@@ -28,6 +30,8 @@ namespace ShiftPlanner
             this.btnRemove = new Button();
             this.btnOk = new Button();
             this.btnCancel = new Button();
+            this.lblYear = new Label();
+            this.nudYear = new NumericUpDown();
             this.SuspendLayout();
 
             // dtHolidays
@@ -37,6 +41,21 @@ namespace ShiftPlanner
             this.dtHolidays.Name = "dtHolidays";
             this.dtHolidays.RowTemplate.Height = 21;
             this.dtHolidays.Size = new System.Drawing.Size(360, 208);
+
+            // lblYear
+            this.lblYear.AutoSize = true;
+            this.lblYear.Location = new System.Drawing.Point(174, 17);
+            this.lblYear.Name = "lblYear";
+            this.lblYear.Size = new System.Drawing.Size(29, 12);
+            this.lblYear.Text = "年";
+
+            // nudYear
+            this.nudYear.Location = new System.Drawing.Point(209, 13);
+            this.nudYear.Maximum = new decimal(new int[] { 3000, 0, 0, 0 });
+            this.nudYear.Minimum = new decimal(new int[] { 2000, 0, 0, 0 });
+            this.nudYear.Name = "nudYear";
+            this.nudYear.Size = new System.Drawing.Size(70, 19);
+            this.nudYear.ValueChanged += new EventHandler(this.NudYear_ValueChanged);
 
             // btnAdd
             this.btnAdd.Location = new System.Drawing.Point(12, 12);
@@ -77,6 +96,8 @@ namespace ShiftPlanner
             this.Controls.Add(this.dtHolidays);
             this.Controls.Add(this.btnAdd);
             this.Controls.Add(this.btnRemove);
+            this.Controls.Add(this.lblYear);
+            this.Controls.Add(this.nudYear);
             this.Controls.Add(this.btnOk);
             this.Controls.Add(this.btnCancel);
             this.FormBorderStyle = FormBorderStyle.FixedDialog;

--- a/ShiftPlanner/HolidayMasterForm.cs
+++ b/ShiftPlanner/HolidayMasterForm.cs
@@ -10,13 +10,23 @@ namespace ShiftPlanner
     /// </summary>
     public partial class HolidayMasterForm : Form
     {
-        private readonly BindingList<CustomHoliday> holidays;
+        // 全祝日リスト
+        private readonly List<CustomHoliday> holidaySource;
+        // 表示用リスト
+        private readonly BindingList<CustomHoliday> filteredHolidays;
 
         public HolidayMasterForm(List<CustomHoliday> holidays)
         {
-            this.holidays = new BindingList<CustomHoliday>(holidays ?? new List<CustomHoliday>());
+            // 元のリストを保持
+            this.holidaySource = holidays ?? new List<CustomHoliday>();
+            // 表示年でフィルタしたリストを作成
+            int year = DateTime.Today.Year;
+            this.filteredHolidays = new BindingList<CustomHoliday>(
+                new List<CustomHoliday>(holidaySource.FindAll(h => h.Date.Year == year)));
             InitializeComponent();
-            dtHolidays.DataSource = this.holidays;
+            // 年の初期値を設定
+            nudYear.Value = year;
+            dtHolidays.DataSource = this.filteredHolidays;
             dtHolidays.AutoGenerateColumns = true;
 
             // ヘッダー文字列を日本語化
@@ -35,14 +45,18 @@ namespace ShiftPlanner
 
         private void BtnAdd_Click(object sender, EventArgs e)
         {
-            holidays.Add(new CustomHoliday { Date = DateTime.Today, Name = "新しい祝日" });
+            int year = (int)nudYear.Value;
+            var newHoliday = new CustomHoliday { Date = new DateTime(year, 1, 1), Name = "新しい祝日" };
+            holidaySource.Add(newHoliday);
+            filteredHolidays.Add(newHoliday);
         }
 
         private void BtnRemove_Click(object sender, EventArgs e)
         {
             if (dtHolidays.CurrentRow?.DataBoundItem is CustomHoliday h)
             {
-                holidays.Remove(h);
+                holidaySource.Remove(h);
+                filteredHolidays.Remove(h);
             }
         }
 
@@ -54,6 +68,27 @@ namespace ShiftPlanner
         private void BtnCancel_Click(object sender, EventArgs e)
         {
             this.DialogResult = DialogResult.Cancel;
+        }
+
+        private void NudYear_ValueChanged(object sender, EventArgs e)
+        {
+            UpdateFilteredHolidays();
+        }
+
+        /// <summary>
+        /// 表示年を変更した際にリストを更新します。
+        /// </summary>
+        private void UpdateFilteredHolidays()
+        {
+            int year = (int)nudYear.Value;
+            filteredHolidays.Clear();
+            foreach (var h in holidaySource)
+            {
+                if (h.Date.Year == year)
+                {
+                    filteredHolidays.Add(h);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## 変更内容
- 祝日マスター画面に年指定用の `NumericUpDown` とラベルを追加
- 指定した年の祝日のみ表示されるようフィルタリング処理を実装
- 年を切り替えると一覧が更新されるようイベントを追加

## テスト
- `dotnet` コマンドが存在しないためビルドを実行できませんでした

------
https://chatgpt.com/codex/tasks/task_e_68453d8f11c4833398de871d4cdcb7b2