### PR TITLE
null 例外の修正

### DIFF
--- a/ShiftPlanner/MainForm.Designer.cs
+++ b/ShiftPlanner/MainForm.Designer.cs
@@ -63,6 +63,8 @@ namespace ShiftPlanner
             this.dtShift = new System.Windows.Forms.DataGridView();
             this.dtMembers = new System.Windows.Forms.DataGridView();
             this.dtRequests = new System.Windows.Forms.DataGridView();
+            this.cmbHolidayLimit = new System.Windows.Forms.ComboBox();
+            this.lblHolidayLimit = new System.Windows.Forms.Label();
             this.btnAddMember = new System.Windows.Forms.Button();
             this.btnRemoveMember = new System.Windows.Forms.Button();
             this.btnAddRequest = new System.Windows.Forms.Button();


### PR DESCRIPTION
## 概要
lblHolidayLimit が null となりビルド時に NullReferenceException が発生する問題を修正しました。Designer ファイルでラベルとコンボボックスのインスタンス生成が抜けていたため、`InitializeComponent` 内で明示的に生成するよう追加しました。

## 変更内容
- `MainForm.Designer.cs` で `cmbHolidayLimit` と `lblHolidayLimit` を初期化するコードを追加

## テスト
- `dotnet build` は実行できない環境のため未実行


------
https://chatgpt.com/codex/tasks/task_e_68456593d35c8333bba4aa725c98ce79