### PR TITLE
勤務時間マスター追加

### DIFF
--- a/ShiftPlanner/MainForm.Designer.cs
+++ b/ShiftPlanner/MainForm.Designer.cs
@@ -39,6 +39,7 @@ namespace ShiftPlanner
         private ToolStripMenuItem menuHolidayMaster;
         private ToolStripMenuItem menuMemberMaster;
         private ToolStripMenuItem menuSkillGroupMaster;
+        private ToolStripMenuItem menuShiftTimeMaster;
         private DateTimePicker dtp分析月;
         private Label lbl総労働時間;
         private Chart chartシフト分布;
@@ -82,6 +83,7 @@ namespace ShiftPlanner
             this.menuHolidayMaster = new System.Windows.Forms.ToolStripMenuItem();
             this.menuMemberMaster = new System.Windows.Forms.ToolStripMenuItem();
             this.menuSkillGroupMaster = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuShiftTimeMaster = new System.Windows.Forms.ToolStripMenuItem();
             this.dtRequestSummary = new System.Windows.Forms.DataGridView();
             this.dtp分析月 = new System.Windows.Forms.DateTimePicker();
             this.lbl総労働時間 = new System.Windows.Forms.Label();
@@ -144,7 +146,8 @@ namespace ShiftPlanner
             this.menuMaster.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuHolidayMaster,
             this.menuMemberMaster,
-            this.menuSkillGroupMaster});
+            this.menuSkillGroupMaster,
+            this.menuShiftTimeMaster});
             this.menuMaster.Name = "menuMaster";
             this.menuMaster.Size = new System.Drawing.Size(61, 20);
             this.menuMaster.Text = "マスター";
@@ -169,6 +172,13 @@ namespace ShiftPlanner
             this.menuSkillGroupMaster.Size = new System.Drawing.Size(138, 22);
             this.menuSkillGroupMaster.Text = "スキルグループ";
             this.menuSkillGroupMaster.Click += new System.EventHandler(this.menuSkillGroupMaster_Click);
+
+            // menuShiftTimeMaster
+            //
+            this.menuShiftTimeMaster.Name = "menuShiftTimeMaster";
+            this.menuShiftTimeMaster.Size = new System.Drawing.Size(138, 22);
+            this.menuShiftTimeMaster.Text = "勤務時間マスター";
+            this.menuShiftTimeMaster.Click += new System.EventHandler(this.menuShiftTimeMaster_Click);
             //
             // tabControl1
             //

--- a/ShiftPlanner/Member.cs
+++ b/ShiftPlanner/Member.cs
@@ -48,6 +48,12 @@ namespace ShiftPlanner
         public bool WorksOnSunday { get; set; }
 
         /// <summary>
+        /// 出勤時間マスタで定義された勤務名のうち、このメンバーが対応可能なもの。
+        /// </summary>
+        [DataMember]
+        public List<string> AvailableShiftNames { get; set; } = new List<string>();
+
+        /// <summary>
         /// 希望休の日付一覧。
         /// </summary>
         [DataMember]

--- a/ShiftPlanner/ShiftPlanner.csproj
+++ b/ShiftPlanner/ShiftPlanner.csproj
@@ -107,6 +107,13 @@
     <Compile Include="SkillGroupMasterForm.Designer.cs">
       <DependentUpon>SkillGroupMasterForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="ShiftTime.cs" />
+    <Compile Include="ShiftTimeMasterForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="ShiftTimeMasterForm.Designer.cs">
+      <DependentUpon>ShiftTimeMasterForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="ShiftConstraints.cs" />
     <EmbeddedResource Include="MainForm.resx">
       <DependentUpon>MainForm.cs</DependentUpon>

--- a/ShiftPlanner/ShiftTime.cs
+++ b/ShiftPlanner/ShiftTime.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace ShiftPlanner
+{
+    /// <summary>
+    /// 出勤時間マスタの1行を表します。
+    /// </summary>
+    [DataContract]
+    public class ShiftTime
+    {
+        /// <summary>勤務名</summary>
+        [DataMember]
+        public string Name { get; set; } = string.Empty;
+
+        /// <summary>開始時間</summary>
+        [DataMember]
+        public TimeSpan Start { get; set; }
+
+        /// <summary>終了時間</summary>
+        [DataMember]
+        public TimeSpan End { get; set; }
+    }
+}

--- a/ShiftPlanner/ShiftTimeMasterForm.Designer.cs
+++ b/ShiftPlanner/ShiftTimeMasterForm.Designer.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Windows.Forms;
+
+namespace ShiftPlanner
+{
+    public partial class ShiftTimeMasterForm
+    {
+        private System.ComponentModel.IContainer? components = null;
+        private DataGridView dtShiftTimes = null!;
+        private Button btnAdd = null!;
+        private Button btnRemove = null!;
+        private Button btnOk = null!;
+        private Button btnCancel = null!;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && components != null)
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            dtShiftTimes = new DataGridView();
+            btnAdd = new Button();
+            btnRemove = new Button();
+            btnOk = new Button();
+            btnCancel = new Button();
+            SuspendLayout();
+
+            // dtShiftTimes
+            dtShiftTimes.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            dtShiftTimes.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dtShiftTimes.Location = new System.Drawing.Point(12, 41);
+            dtShiftTimes.Name = "dtShiftTimes";
+            dtShiftTimes.RowTemplate.Height = 21;
+            dtShiftTimes.Size = new System.Drawing.Size(360, 208);
+
+            // btnAdd
+            btnAdd.Location = new System.Drawing.Point(12, 12);
+            btnAdd.Name = "btnAdd";
+            btnAdd.Size = new System.Drawing.Size(75, 23);
+            btnAdd.Text = "追加";
+            btnAdd.UseVisualStyleBackColor = true;
+            btnAdd.Click += new EventHandler(BtnAdd_Click);
+
+            // btnRemove
+            btnRemove.Location = new System.Drawing.Point(93, 12);
+            btnRemove.Name = "btnRemove";
+            btnRemove.Size = new System.Drawing.Size(75, 23);
+            btnRemove.Text = "削除";
+            btnRemove.UseVisualStyleBackColor = true;
+            btnRemove.Click += new EventHandler(BtnRemove_Click);
+
+            // btnOk
+            btnOk.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            btnOk.Location = new System.Drawing.Point(216, 255);
+            btnOk.Name = "btnOk";
+            btnOk.Size = new System.Drawing.Size(75, 23);
+            btnOk.Text = "OK";
+            btnOk.UseVisualStyleBackColor = true;
+            btnOk.Click += new EventHandler(BtnOk_Click);
+
+            // btnCancel
+            btnCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            btnCancel.Location = new System.Drawing.Point(297, 255);
+            btnCancel.Name = "btnCancel";
+            btnCancel.Size = new System.Drawing.Size(75, 23);
+            btnCancel.Text = "キャンセル";
+            btnCancel.UseVisualStyleBackColor = true;
+            btnCancel.Click += new EventHandler(BtnCancel_Click);
+
+            // Form
+            ClientSize = new System.Drawing.Size(384, 290);
+            Controls.Add(dtShiftTimes);
+            Controls.Add(btnAdd);
+            Controls.Add(btnRemove);
+            Controls.Add(btnOk);
+            Controls.Add(btnCancel);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            StartPosition = FormStartPosition.CenterParent;
+            Text = "勤務時間マスター";
+
+            ResumeLayout(false);
+        }
+    }
+}

--- a/ShiftPlanner/ShiftTimeMasterForm.cs
+++ b/ShiftPlanner/ShiftTimeMasterForm.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace ShiftPlanner
+{
+    /// <summary>
+    /// 出勤時間マスタ編集用フォーム
+    /// </summary>
+    public partial class ShiftTimeMasterForm : Form
+    {
+        private readonly BindingList<ShiftTime> _shiftTimes;
+
+        public ShiftTimeMasterForm(List<ShiftTime> shiftTimes)
+        {
+            _shiftTimes = new BindingList<ShiftTime>(shiftTimes ?? new List<ShiftTime>());
+            InitializeComponent();
+            dtShiftTimes.DataSource = _shiftTimes;
+            SetupGrid();
+        }
+
+        /// <summary>
+        /// 編集後の出勤時間一覧を取得します。
+        /// </summary>
+        public List<ShiftTime> ShiftTimes => _shiftTimes.ToList();
+
+        private void BtnAdd_Click(object? sender, EventArgs e)
+        {
+            _shiftTimes.Add(new ShiftTime
+            {
+                Name = "新規勤務",
+                Start = new TimeSpan(9, 0, 0),
+                End = new TimeSpan(18, 0, 0)
+            });
+        }
+
+        private void BtnRemove_Click(object? sender, EventArgs e)
+        {
+            if (dtShiftTimes.CurrentRow?.DataBoundItem is ShiftTime st)
+            {
+                _shiftTimes.Remove(st);
+            }
+        }
+
+        private void BtnOk_Click(object? sender, EventArgs e)
+        {
+            DialogResult = DialogResult.OK;
+        }
+
+        private void BtnCancel_Click(object? sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Cancel;
+        }
+
+        private void SetupGrid()
+        {
+            dtShiftTimes.AutoGenerateColumns = true;
+            foreach (DataGridViewColumn col in dtShiftTimes.Columns)
+            {
+                if (col == null || string.IsNullOrEmpty(col.Name))
+                {
+                    continue;
+                }
+
+                switch (col.Name)
+                {
+                    case nameof(ShiftTime.Name):
+                        col.HeaderText = "勤務名";
+                        break;
+                    case nameof(ShiftTime.Start):
+                        col.HeaderText = "開始時間";
+                        break;
+                    case nameof(ShiftTime.End):
+                        col.HeaderText = "終了時間";
+                        break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 勤務時間を管理する `ShiftTime` クラスを追加
- 勤務時間マスター編集フォームを実装
- メンバー情報に対応可能な勤務名リストを追加
- メンバー編集画面で勤務名ごとのチェック列を表示
- メニューに勤務時間マスター項目を追加し保存/読み込み処理を実装

## Testing
- `dotnet restore ShiftPlanner.sln` *(fails: command not found)*
- `dotnet build ShiftPlanner.sln -c Release` *(fails: command not found)*
- `dotnet test ShiftPlanner.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456b0f73fc83339cee1cf8ee9e97e2