### PR TITLE
グリッドでの直接行追加を禁止

### DIFF
--- a/ShiftPlanner/HolidayMasterForm.Designer.cs
+++ b/ShiftPlanner/HolidayMasterForm.Designer.cs
@@ -41,6 +41,8 @@ namespace ShiftPlanner
             this.dtHolidays.Name = "dtHolidays";
             this.dtHolidays.RowTemplate.Height = 21;
             this.dtHolidays.Size = new System.Drawing.Size(360, 208);
+            // 直接行を追加できないよう設定
+            this.dtHolidays.AllowUserToAddRows = false;
 
             // lblYear
             this.lblYear.AutoSize = true;

--- a/ShiftPlanner/MainForm.Designer.cs
+++ b/ShiftPlanner/MainForm.Designer.cs
@@ -217,6 +217,7 @@ namespace ShiftPlanner
             this.dtShift.Location = new System.Drawing.Point(3, 35);
             this.dtShift.Name = "dtShift";
             this.dtShift.RowTemplate.Height = 21;
+            this.dtShift.AllowUserToAddRows = false; // 直接行を追加させない
             // TabPage 高さ変更に合わせデータグリッドの高さを調整
             this.dtShift.Size = new System.Drawing.Size(1379, 773);
             this.dtShift.TabIndex = 1;
@@ -325,6 +326,7 @@ namespace ShiftPlanner
             this.dtMembers.Location = new System.Drawing.Point(3, 35);
             this.dtMembers.Name = "dtMembers";
             this.dtMembers.RowTemplate.Height = 21;
+            this.dtMembers.AllowUserToAddRows = false; // 直接行を追加させない
             // TabPage 高さ変更に合わせデータグリッドの高さを調整
             this.dtMembers.Size = new System.Drawing.Size(1379, 773);
             this.dtMembers.TabIndex = 2;
@@ -378,6 +380,7 @@ namespace ShiftPlanner
             this.dtRequests.Location = new System.Drawing.Point(3, 35);
             this.dtRequests.Name = "dtRequests";
             this.dtRequests.RowTemplate.Height = 21;
+            this.dtRequests.AllowUserToAddRows = false; // 直接行を追加させない
             this.dtRequests.Size = new System.Drawing.Size(680, 800);
             this.dtRequests.TabIndex = 2;
 
@@ -389,6 +392,7 @@ namespace ShiftPlanner
             this.dtRequestSummary.Location = new System.Drawing.Point(689, 35);
             this.dtRequestSummary.Name = "dtRequestSummary";
             this.dtRequestSummary.RowTemplate.Height = 21;
+            this.dtRequestSummary.AllowUserToAddRows = false; // 直接行を追加させない
             this.dtRequestSummary.Size = new System.Drawing.Size(693, 800);
             this.dtRequestSummary.TabIndex = 7;
 

--- a/ShiftPlanner/MemberMasterForm.Designer.cs
+++ b/ShiftPlanner/MemberMasterForm.Designer.cs
@@ -37,6 +37,8 @@ namespace ShiftPlanner
             this.dtMembers.Name = "dtMembers";
             this.dtMembers.RowTemplate.Height = 21;
             this.dtMembers.Size = new System.Drawing.Size(560, 308);
+            // 直接行を追加できないよう設定
+            this.dtMembers.AllowUserToAddRows = false;
 
             // btnAdd
             this.btnAdd.Location = new System.Drawing.Point(12, 12);

--- a/ShiftPlanner/ShiftTimeMasterForm.Designer.cs
+++ b/ShiftPlanner/ShiftTimeMasterForm.Designer.cs
@@ -37,6 +37,8 @@ namespace ShiftPlanner
             dtShiftTimes.Name = "dtShiftTimes";
             dtShiftTimes.RowTemplate.Height = 21;
             dtShiftTimes.Size = new System.Drawing.Size(360, 208);
+            // 直接行を追加できないよう設定
+            dtShiftTimes.AllowUserToAddRows = false;
 
             // btnAdd
             btnAdd.Location = new System.Drawing.Point(12, 12);

--- a/ShiftPlanner/SkillGroupMasterForm.Designer.cs
+++ b/ShiftPlanner/SkillGroupMasterForm.Designer.cs
@@ -37,6 +37,8 @@ namespace ShiftPlanner
             dtSkillGroups.Name = "dtSkillGroups";
             dtSkillGroups.RowTemplate.Height = 21;
             dtSkillGroups.Size = new System.Drawing.Size(360, 208);
+            // 直接行を追加できないよう設定
+            dtSkillGroups.AllowUserToAddRows = false;
 
             // btnAdd
             btnAdd.Location = new System.Drawing.Point(12, 12);


### PR DESCRIPTION
## 変更内容
- 祝日・メンバー・スキルグループ・勤務時間各マスターの `DataGridView` に `AllowUserToAddRows = false` を追加
- メインフォーム内のシフト表や希望一覧など全ての `DataGridView` に同じ設定を追加

## 動作確認
- `dotnet build` を試みましたが、環境に `dotnet` コマンドが存在せずビルドを実行できませんでした。


------
https://chatgpt.com/codex/tasks/task_e_6845705d71348333afc2bb918f8e469b