### PR TITLE
勤怠時間マスタを更新ボタンに反映

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -367,6 +367,36 @@ namespace ShiftPlanner
         }
 
         /// <summary>
+        /// 勤怠時間マスターの設定をシフトフレームへ適用します。
+        /// </summary>
+        private void ApplyShiftTimesFromMaster()
+        {
+            if (shiftFrames == null || shiftTimes == null)
+            {
+                return; // nullチェック
+            }
+
+            foreach (var frame in shiftFrames)
+            {
+                if (frame == null || string.IsNullOrWhiteSpace(frame.ShiftType))
+                {
+                    continue;
+                }
+
+                var master = shiftTimes.FirstOrDefault(t =>
+                    t != null && string.Equals(t.Name, frame.ShiftType, StringComparison.OrdinalIgnoreCase));
+
+                if (master != null)
+                {
+                    frame.ShiftStart = master.Start;
+                    frame.ShiftEnd = master.End;
+                }
+            }
+
+            SaveFrames();
+        }
+
+        /// <summary>
         /// 割り当て結果を読み込みます。
         /// </summary>
         private void LoadAssignments()
@@ -830,12 +860,15 @@ namespace ShiftPlanner
                 var frame = shiftFrames.FirstOrDefault(f => f.Date.Date == key.date && f.ShiftType == shiftType);
                 if (frame == null)
                 {
+                    var master = shiftTimes?.FirstOrDefault(t =>
+                        t != null && string.Equals(t.Name, shiftType, StringComparison.OrdinalIgnoreCase));
+
                     frame = new ShiftFrame
                     {
                         Date = key.date,
                         ShiftType = shiftType,
-                        ShiftStart = TimeSpan.FromHours(9),
-                        ShiftEnd = TimeSpan.FromHours(17),
+                        ShiftStart = master?.Start ?? TimeSpan.Zero,
+                        ShiftEnd = master?.End ?? TimeSpan.Zero,
                         RequiredNumber = 1
                     };
                     shiftFrames.Add(frame);
@@ -1077,6 +1110,9 @@ namespace ShiftPlanner
 
                 // 必要人数グリッドの内容をシフトフレームへ反映
                 ApplyRequiredNumbersFromGrid();
+
+                // シフト時間マスターの内容をシフトフレームへ反映
+                ApplyShiftTimesFromMaster();
 
                 // 自動割当を生成
                 assignments = ShiftGenerator.GenerateBaseShift(shiftFrames, members, shiftRequests);


### PR DESCRIPTION
## 概要
- 更新ボタン押下時に勤務時間マスタをシフトフレームへ適用
- 手入力シフトからフレームを新規作成する際もマスタ値を利用
- 勤怠時間マスタ反映用のメソッド `ApplyShiftTimesFromMaster` を追加

## テスト
- `dotnet build` を試みましたが `dotnet` コマンドが存在せずビルドできませんでした

------
https://chatgpt.com/codex/tasks/task_e_6845744fb61083339947d71b2178df01