### PR TITLE
不要な必要人数のサンプル設定を除去

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -842,8 +842,8 @@ namespace ShiftPlanner
                         Date = key.date,
                         ShiftType = shiftType,
                         ShiftStart = master?.Start ?? TimeSpan.Zero,
-                        ShiftEnd = master?.End ?? TimeSpan.Zero,
-                        RequiredNumber = 1
+                        ShiftEnd = master?.End ?? TimeSpan.Zero
+                        // RequiredNumber は初期値 0 のままとする
                     };
                     shiftFrames.Add(frame);
                 }


### PR DESCRIPTION
## 概要
手動割当を処理する際、シフトフレームが存在しない場合に `RequiredNumber` を 1 として生成していました。この初期値はサンプルデータのため不要と判断し、設定を削除しました。

## 変更内容
- `ApplyManualAssignments` 内で新規 `ShiftFrame` 生成時の `RequiredNumber` 設定を削除
- コメントを追加し、初期値が 0 である旨を明記

## テスト
- `dotnet build` を実行しようとしましたが、環境に `dotnet` が存在せずビルドできませんでした。


------
https://chatgpt.com/codex/tasks/task_e_68457642b7a08333ab2bad226357002f