### PR TITLE
整理されていないコードの削除

### DIFF
--- a/ShiftPlanner/DataGridViewHelper.cs
+++ b/ShiftPlanner/DataGridViewHelper.cs
@@ -1,0 +1,30 @@
+using System.Windows.Forms;
+
+namespace ShiftPlanner
+{
+    /// <summary>
+    /// DataGridView に関する補助機能を提供するクラス
+    /// </summary>
+    public static class DataGridViewHelper
+    {
+        /// <summary>
+        /// すべての列をソート不可に設定します。
+        /// </summary>
+        /// <param name="grid">対象の DataGridView</param>
+        public static void SetColumnsNotSortable(DataGridView? grid)
+        {
+            if (grid?.Columns == null)
+            {
+                return;
+            }
+
+            foreach (DataGridViewColumn column in grid.Columns)
+            {
+                if (column != null)
+                {
+                    column.SortMode = DataGridViewColumnSortMode.NotSortable;
+                }
+            }
+        }
+    }
+}

--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -604,7 +604,7 @@ namespace ShiftPlanner
             }
 
             // すべての列をソート不可に設定
-            SetColumnsNotSortable(dtShift);
+            DataGridViewHelper.SetColumnsNotSortable(dtShift);
 
             // 割当人数行の不足・過剰を色分け
             try
@@ -684,23 +684,6 @@ namespace ShiftPlanner
         /// 指定したグリッドの列をすべてソート不可に設定します。
         /// </summary>
         /// <param name="grid">対象のDataGridView</param>
-        private static void SetColumnsNotSortable(DataGridView grid)
-        {
-            if (grid == null || grid.Columns == null)
-            {
-                return; // null 安全対策
-            }
-
-            foreach (DataGridViewColumn column in grid.Columns)
-            {
-                if (column != null)
-                {
-                    column.SortMode = DataGridViewColumnSortMode.NotSortable;
-                }
-            }
-        }
-
-        /// <summary>
         /// シフト表の「必要人数」行から値を取得してシフトフレームを更新します。
         /// </summary>
         private void ApplyRequiredNumbersFromGrid()
@@ -922,7 +905,7 @@ namespace ShiftPlanner
                 }
 
                 // 列をソート不可に設定
-                SetColumnsNotSortable(dtMembers);
+                DataGridViewHelper.SetColumnsNotSortable(dtMembers);
             }
             catch (Exception ex)
             {
@@ -1001,7 +984,7 @@ namespace ShiftPlanner
                 dtRequests.DataSource = shiftRequests ?? new List<ShiftRequest>();
 
                 // 列をソート不可に設定
-                SetColumnsNotSortable(dtRequests);
+                DataGridViewHelper.SetColumnsNotSortable(dtRequests);
             }
             catch (Exception ex)
             {
@@ -1371,7 +1354,7 @@ namespace ShiftPlanner
                 }).ToList();
 
                 dtRequestSummary.DataSource = list;
-                SetColumnsNotSortable(dtRequestSummary);
+                DataGridViewHelper.SetColumnsNotSortable(dtRequestSummary);
             }
             catch (Exception ex)
             {

--- a/ShiftPlanner/MemberMasterForm.cs
+++ b/ShiftPlanner/MemberMasterForm.cs
@@ -139,7 +139,7 @@ namespace ShiftPlanner
             dtMembers.CellFormatting += DtMembers_CellFormatting;
             dtMembers.CellParsing += DtMembers_CellParsing;
             dtMembers.CurrentCellDirtyStateChanged += DtMembers_CurrentCellDirtyStateChanged;
-            SetColumnsNotSortable(dtMembers);
+            DataGridViewHelper.SetColumnsNotSortable(dtMembers);
         }
 
         private void DtMembers_CurrentCellDirtyStateChanged(object? sender, EventArgs e)
@@ -211,20 +211,5 @@ namespace ShiftPlanner
 
         /// <summary>
         /// 指定グリッドの列をすべてソート不可にします。
-        /// </summary>
-        private static void SetColumnsNotSortable(DataGridView grid)
-        {
-            if (grid == null || grid.Columns == null)
-            {
-                return;
-            }
-            foreach (DataGridViewColumn column in grid.Columns)
-            {
-                if (column != null)
-                {
-                    column.SortMode = DataGridViewColumnSortMode.NotSortable;
-                }
-            }
-        }
     }
 }

--- a/ShiftPlanner/ShiftAnalyzer.cs
+++ b/ShiftPlanner/ShiftAnalyzer.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.IO;
-using System.Windows.Forms.DataVisualization.Charting;
 
 namespace ShiftPlanner
 {
@@ -22,15 +21,6 @@ namespace ShiftPlanner
                 .Aggregate(TimeSpan.Zero, (acc, s) => acc + (s.ShiftEnd - s.ShiftStart));
         }
 
-        /// <summary>
-        /// 指定した年の総労働時間を計算します。
-        /// </summary>
-        public static TimeSpan CalculateAnnualHours(IEnumerable<ShiftFrame> shifts, int year)
-        {
-            return shifts
-                .Where(s => s.Date.Year == year)
-                .Aggregate(TimeSpan.Zero, (acc, s) => acc + (s.ShiftEnd - s.ShiftStart));
-        }
 
         /// <summary>
         /// 指定した月のシフトタイプごとの件数を取得します。
@@ -52,31 +42,6 @@ namespace ShiftPlanner
                 .ToDictionary(g => g.Key, g => g.Count());
         }
 
-        /// <summary>
-        /// シフトタイプごとの分布を円グラフとして画像出力します。
-        /// </summary>
-        public static void ExportDistributionChart(IEnumerable<ShiftFrame> shifts, string path)
-        {
-            var counts = shifts.GroupBy(s => s.ShiftType)
-                               .Select(g => new { Type = g.Key, Count = g.Count() })
-                               .ToList();
-
-            using (var chart = new Chart())
-            {
-                chart.Size = new System.Drawing.Size(600, 400);
-                chart.ChartAreas.Add(new ChartArea());
-                var series = new Series
-                {
-                    ChartType = SeriesChartType.Pie
-                };
-                foreach (var item in counts)
-                {
-                    series.Points.AddXY(item.Type, item.Count);
-                }
-                chart.Series.Add(series);
-                chart.SaveImage(path, ChartImageFormat.Png);
-            }
-        }
 
         /// <summary>
         /// シフトタイプごとの分布をCSV形式で出力します。


### PR DESCRIPTION
## 変更点
- 重複していた `SetColumnsNotSortable` メソッドを `DataGridViewHelper` クラスとして共通化
- 使用されていなかった `ShiftAnalyzer.CalculateAnnualHours` と `ExportDistributionChart` を削除
- 上記に伴う呼び出し箇所の修正

## テスト
- `dotnet build` を試みましたが、環境に `dotnet` コマンドが存在せず実行できませんでした

------
https://chatgpt.com/codex/tasks/task_e_68459061c27c8333bb0ac8b1642ce861