### PR TITLE
Fix missing DataGridViewHelper reference

### DIFF
--- a/ShiftPlanner/ShiftPlanner.csproj
+++ b/ShiftPlanner/ShiftPlanner.csproj
@@ -86,6 +86,8 @@
     <Compile Include="ShiftGenerator.cs" />
     <Compile Include="JapaneseHolidayHelper.cs" />
     <Compile Include="CustomHoliday.cs" />
+    <!-- DataGridView の拡張メソッド -->
+    <Compile Include="DataGridViewHelper.cs" />
     <!-- メンバーごとの希望件数サマリ表示用クラス -->
     <Compile Include="RequestSummary.cs" />
     <Compile Include="HolidayMasterForm.cs">


### PR DESCRIPTION
## Summary
- プロジェクトファイルに `DataGridViewHelper.cs` を追加しました

## Testing
- `dotnet restore ShiftPlanner.sln`
- `dotnet build ShiftPlanner.sln -c Release` *(失敗: .NET Framework 4.8 Developer Pack がないため)*

------
https://chatgpt.com/codex/tasks/task_e_684592de03248333a6a35c0e0c3a94b2