### PR TITLE
シフト表列幅の自動調整

### DIFF
--- a/ShiftPlanner/DataGridViewHelper.cs
+++ b/ShiftPlanner/DataGridViewHelper.cs
@@ -26,5 +26,20 @@ namespace ShiftPlanner
                 }
             }
         }
+
+        /// <summary>
+        /// 列幅をヘッダー文字列が収まる程度に自動調整します。
+        /// </summary>
+        /// <param name="grid">対象の DataGridView</param>
+        public static void AdjustColumnWidthToHeader(DataGridView? grid)
+        {
+            if (grid == null)
+            {
+                return;
+            }
+
+            // 列ごとにヘッダーを基準に自動サイズ設定
+            grid.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.ColumnHeader;
+        }
     }
 }

--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -872,6 +872,8 @@ namespace ShiftPlanner
 
             dtShifts.DataSource = shiftTable;
             DataGridViewHelper.SetColumnsNotSortable(dtShifts);
+            // 列幅をヘッダー表示に合わせて調整
+            DataGridViewHelper.AdjustColumnWidthToHeader(dtShifts);
 
             dtShifts.CellFormatting -= DtShifts_CellFormatting;
             dtShifts.CellFormatting += DtShifts_CellFormatting;


### PR DESCRIPTION
## 概要
- DataGridViewHelper に列幅をヘッダー幅に合わせるメソッドを追加
- シフト表表示時に上記メソッドを利用して各列を狭く表示

## テスト
- `dotnet restore` は成功
- `dotnet build` は .NET Framework 4.8 の参照が無く失敗

------
https://chatgpt.com/codex/tasks/task_e_6846aa715fd0833395fe251e9d540a41