### PR TITLE
設定保存機能と必要人数デフォルト設定を追加

### DIFF
--- a/ShiftPlanner/AppSettings.cs
+++ b/ShiftPlanner/AppSettings.cs
@@ -1,0 +1,17 @@
+using System.Runtime.Serialization;
+
+namespace ShiftPlanner
+{
+    /// <summary>
+    /// アプリ全体の設定を保持するクラス。
+    /// </summary>
+    [DataContract]
+    public class AppSettings
+    {
+        [DataMember]
+        public int HolidayLimit { get; set; } = 3;
+
+        [DataMember]
+        public int DefaultRequired { get; set; } = 1;
+    }
+}

--- a/ShiftPlanner/MainForm.Designer.cs
+++ b/ShiftPlanner/MainForm.Designer.cs
@@ -19,6 +19,8 @@ namespace ShiftPlanner
         private DataGridView dtRequestSummary;
         private ComboBox cmbHolidayLimit;
         private Label lblHolidayLimit;
+        private ComboBox cmbDefaultRequired;
+        private Label lblDefaultRequired;
         private Button btnAddRequest;
         private Button btnRemoveRequest;
         private DateTimePicker dtp分析月;
@@ -61,6 +63,8 @@ namespace ShiftPlanner
             this.btnAddRequest = new System.Windows.Forms.Button();
             this.cmbHolidayLimit = new System.Windows.Forms.ComboBox();
             this.lblHolidayLimit = new System.Windows.Forms.Label();
+            this.cmbDefaultRequired = new System.Windows.Forms.ComboBox();
+            this.lblDefaultRequired = new System.Windows.Forms.Label();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.menuFile = new System.Windows.Forms.ToolStripMenuItem();
             this.menuExportAnalysisCsv = new System.Windows.Forms.ToolStripMenuItem();
@@ -98,6 +102,8 @@ namespace ShiftPlanner
             // tabShift
             //
             this.tabShift.Controls.Add(this.dtShifts);
+            this.tabShift.Controls.Add(this.cmbDefaultRequired);
+            this.tabShift.Controls.Add(this.lblDefaultRequired);
             this.tabShift.Controls.Add(this.btnShiftGenerate);
             this.tabShift.Location = new System.Drawing.Point(4, 22);
             this.tabShift.Name = "tabShift";
@@ -118,6 +124,36 @@ namespace ShiftPlanner
             this.dtShifts.RowTemplate.Height = 21;
             this.dtShifts.Size = new System.Drawing.Size(1373, 764);
             this.dtShifts.TabIndex = 1;
+            //
+            // cmbDefaultRequired
+            //
+            this.cmbDefaultRequired.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbDefaultRequired.FormattingEnabled = true;
+            this.cmbDefaultRequired.Items.AddRange(new object[] {
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10"});
+            this.cmbDefaultRequired.Location = new System.Drawing.Point(200, 8);
+            this.cmbDefaultRequired.Name = "cmbDefaultRequired";
+            this.cmbDefaultRequired.Size = new System.Drawing.Size(60, 20);
+            this.cmbDefaultRequired.TabIndex = 3;
+            this.cmbDefaultRequired.SelectedIndexChanged += new System.EventHandler(this.CmbDefaultRequired_SelectedIndexChanged);
+            //
+            // lblDefaultRequired
+            //
+            this.lblDefaultRequired.AutoSize = true;
+            this.lblDefaultRequired.Location = new System.Drawing.Point(110, 11);
+            this.lblDefaultRequired.Name = "lblDefaultRequired";
+            this.lblDefaultRequired.Size = new System.Drawing.Size(84, 12);
+            this.lblDefaultRequired.TabIndex = 2;
+            this.lblDefaultRequired.Text = "必要人数デフォルト";
             //
             // btnShiftGenerate
             //
@@ -334,6 +370,7 @@ namespace ShiftPlanner
             this.Name = "MainForm";
             this.tabControl1.ResumeLayout(false);
             this.tabShift.ResumeLayout(false);
+            this.tabShift.PerformLayout();
             this.tabPage3.ResumeLayout(false);
             this.tabPage3.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dtRequestSummary)).EndInit();

--- a/ShiftPlanner/ShiftPlanner.csproj
+++ b/ShiftPlanner/ShiftPlanner.csproj
@@ -88,6 +88,7 @@
     <Compile Include="CustomHoliday.cs" />
     <!-- DataGridView の拡張メソッド -->
     <Compile Include="DataGridViewHelper.cs" />
+    <Compile Include="AppSettings.cs" />
     <!-- メンバーごとの希望件数サマリ表示用クラス -->
     <Compile Include="RequestSummary.cs" />
     <Compile Include="HolidayMasterForm.cs">


### PR DESCRIPTION
## 概要
- 休み希望上限と必要人数デフォルト値を保存する `AppSettings` を追加
- シフト表タブに必要人数デフォルト値を設定するドロップダウンを配置
- 上記値の変更時にシフト表の"必要人数"行を一括更新
- シフト表データの保存/読み込み機能を実装
- フォーム終了時に各種設定とシフト表を保存するよう更新

## テスト
- `dotnet build` は環境に `dotnet` が存在しないため実行できず

------
https://chatgpt.com/codex/tasks/task_e_6848063629008333ae548f7b9f0b391f