### PR TITLE
Use shared Random instance

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -49,6 +49,9 @@ namespace ShiftPlanner
         // シフト表用のテーブル
         private DataTable shiftTable = new DataTable();
 
+        // 乱数生成用の共有インスタンス
+        private static readonly Random _rand = new Random();
+
         // 日付列が開始するインデックス
         private int dateColumnStartIndex = 1;
 
@@ -1085,7 +1088,6 @@ namespace ShiftPlanner
 
             var baseDate = new DateTime(dtp対象月.Value.Year, dtp対象月.Value.Month, 1);
             var days = DateTime.DaysInMonth(baseDate.Year, baseDate.Month);
-            var rand = new Random();
 
             // メンバーごとの追加休日日リストを作成
             var extraHolidays = new Dictionary<int, HashSet<int>>();
@@ -1099,7 +1101,7 @@ namespace ShiftPlanner
                 var set = new HashSet<int>();
                 for (int i = 0; i < need && cand.Count > 0; i++)
                 {
-                    int idx = rand.Next(cand.Count);
+                    int idx = _rand.Next(cand.Count);
                     set.Add(cand[idx]);
                     cand.RemoveAt(idx);
                 }
@@ -1148,7 +1150,7 @@ namespace ShiftPlanner
                         else
                         {
                             var shifts = m.AvailableShiftNames.Count > 0 ? m.AvailableShiftNames : shiftTimes.Select(s => s.Name).ToList();
-                            var shiftName = shifts.Count > 0 ? shifts[rand.Next(shifts.Count)] : string.Empty;
+                            var shiftName = shifts.Count > 0 ? shifts[_rand.Next(shifts.Count)] : string.Empty;
                             if (req != null)
                             {
                                 value = $"希{shiftName}";

--- a/ShiftPlanner/ShiftGenerator.cs
+++ b/ShiftPlanner/ShiftGenerator.cs
@@ -6,6 +6,8 @@ namespace ShiftPlanner
 {
     public static class ShiftGenerator
     {
+        // 乱数生成用の共有インスタンス
+        private static readonly Random _rand = new Random();
         /// <summary>
         /// シフト枠に必要な人数を満たすようメンバーを割り当てます。
         /// </summary>
@@ -24,8 +26,7 @@ namespace ShiftPlanner
                 return assignments; // nullチェック
             }
 
-            // ランダム選択用のインスタンス
-            var random = new Random();
+            // 乱数生成用インスタンスはクラスで共有
 
             foreach (var frame in frames.OrderBy(f => f.Date))
             {
@@ -75,7 +76,8 @@ namespace ShiftPlanner
                 // 残りの枠はランダムに選択
                 if (others.Count > 0)
                 {
-                    var shuffled = others.OrderBy(_ => random.Next()).ToList();
+                    // OrderBy で乱数を使用してシャッフル
+                    var shuffled = others.OrderBy(_ => _rand.Next()).ToList();
                     foreach (var m in shuffled)
                     {
                         if (assigned.Count >= frame.RequiredNumber)


### PR DESCRIPTION
## Summary
- `MainForm` と `ShiftGenerator` に乱数用の静的フィールド `_rand` を追加
- `new Random()` を `_rand` に置き換え

## Testing
- `dotnet build ShiftPlanner.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a3c15b15c8333862ef030a9531d5e