### PR TITLE
メンバー更新時にシフト表へ反映

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -672,6 +672,9 @@ namespace ShiftPlanner
             }
 
             SaveMembers();
+            // 新規メンバーをシフト表と希望一覧に反映
+            SetupShiftGrid();
+            SetupRequestGrid();
         }
 
         private void btnAddRequest_Click(object sender, EventArgs e)
@@ -766,6 +769,9 @@ namespace ShiftPlanner
                 {
                     // 編集結果はそのまま反映されるため再表示のみ
                     SaveMembers();
+                    // メンバー変更をシフト表と希望一覧に反映
+                    SetupShiftGrid();
+                    SetupRequestGrid();
                 }
             }
         }
@@ -948,6 +954,9 @@ namespace ShiftPlanner
         /// </summary>
         private void BtnShiftGenerate_Click(object? sender, EventArgs e)
         {
+            // メンバー数が変更されている可能性があるため
+            // 事前にグリッドを再構築して反映させる
+            SetupShiftGrid();
             GenerateRandomShifts();
             UpdateAttendanceCounts();
         }


### PR DESCRIPTION
## 変更内容
- メンバーマスターでの編集結果を保存後、シフト表と希望一覧を再構築するよう修正
- メンバー追加ボタンでも同様にグリッドを再構築
- シフト自動生成ボタン押下時にグリッドを再構築してから生成を実行

## テスト
- `dotnet build` が利用できない環境のためビルドは未実施

------
https://chatgpt.com/codex/tasks/task_e_684a3ff68c308333a315098358a45646