### PR TITLE
グリッド表示の自動調整とフォームのサイズ変更対応

### DIFF
--- a/ShiftPlanner/DataGridViewHelper.cs
+++ b/ShiftPlanner/DataGridViewHelper.cs
@@ -41,5 +41,20 @@ namespace ShiftPlanner
             // 列ごとにヘッダーを基準に自動サイズ設定
             grid.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.ColumnHeader;
         }
+
+        /// <summary>
+        /// フォームの幅に合わせて列幅を自動調整します。
+        /// </summary>
+        /// <param name="grid">対象の DataGridView</param>
+        public static void FitColumnsToGrid(DataGridView? grid)
+        {
+            if (grid == null)
+            {
+                return;
+            }
+
+            // 利用可能な領域で列幅を均等に調整
+            grid.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
+        }
     }
 }

--- a/ShiftPlanner/HolidayMasterForm.Designer.cs
+++ b/ShiftPlanner/HolidayMasterForm.Designer.cs
@@ -102,7 +102,7 @@ namespace ShiftPlanner
             this.Controls.Add(this.nudYear);
             this.Controls.Add(this.btnOk);
             this.Controls.Add(this.btnCancel);
-            this.FormBorderStyle = FormBorderStyle.FixedDialog;
+            this.FormBorderStyle = FormBorderStyle.Sizable;
             this.StartPosition = FormStartPosition.CenterParent;
             this.Text = "祝日マスター";
 

--- a/ShiftPlanner/HolidayMasterForm.cs
+++ b/ShiftPlanner/HolidayMasterForm.cs
@@ -41,6 +41,10 @@ namespace ShiftPlanner
                     col.HeaderText = "名称";
                 }
             }
+
+            // 列幅をフォームのサイズに合わせて調整
+            DataGridViewHelper.SetColumnsNotSortable(dtHolidays);
+            DataGridViewHelper.FitColumnsToGrid(dtHolidays);
         }
 
         private void BtnAdd_Click(object sender, EventArgs e)

--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -669,6 +669,7 @@ namespace ShiftPlanner
 
                 // 列をソート不可に設定
                 DataGridViewHelper.SetColumnsNotSortable(dtRequests);
+                DataGridViewHelper.FitColumnsToGrid(dtRequests);
             }
             catch (Exception ex)
             {
@@ -961,6 +962,7 @@ namespace ShiftPlanner
 
                 dtRequestSummary.DataSource = list;
                 DataGridViewHelper.SetColumnsNotSortable(dtRequestSummary);
+                DataGridViewHelper.FitColumnsToGrid(dtRequestSummary);
             }
             catch (Exception ex)
             {
@@ -1072,6 +1074,7 @@ namespace ShiftPlanner
             DataGridViewHelper.SetColumnsNotSortable(dtShifts);
             // 列幅をヘッダー表示に合わせて調整
             DataGridViewHelper.AdjustColumnWidthToHeader(dtShifts);
+            DataGridViewHelper.FitColumnsToGrid(dtShifts);
 
             dtShifts.CellFormatting -= DtShifts_CellFormatting;
             dtShifts.CellFormatting += DtShifts_CellFormatting;

--- a/ShiftPlanner/MemberMasterForm.Designer.cs
+++ b/ShiftPlanner/MemberMasterForm.Designer.cs
@@ -81,7 +81,7 @@ namespace ShiftPlanner
             this.Controls.Add(this.btnRemove);
             this.Controls.Add(this.btnOk);
             this.Controls.Add(this.btnCancel);
-            this.FormBorderStyle = FormBorderStyle.FixedDialog;
+            this.FormBorderStyle = FormBorderStyle.Sizable;
             this.StartPosition = FormStartPosition.CenterParent;
             this.Text = "メンバーマスター";
 

--- a/ShiftPlanner/MemberMasterForm.cs
+++ b/ShiftPlanner/MemberMasterForm.cs
@@ -209,6 +209,8 @@ namespace ShiftPlanner
             dtMembers.CellParsing += DtMembers_CellParsing;
             dtMembers.CurrentCellDirtyStateChanged += DtMembers_CurrentCellDirtyStateChanged;
             DataGridViewHelper.SetColumnsNotSortable(dtMembers);
+            // フォームサイズに合わせて列幅を自動調整
+            DataGridViewHelper.FitColumnsToGrid(dtMembers);
         }
 
         private void DtMembers_CurrentCellDirtyStateChanged(object? sender, EventArgs e)

--- a/ShiftPlanner/ShiftTimeMasterForm.Designer.cs
+++ b/ShiftPlanner/ShiftTimeMasterForm.Designer.cs
@@ -81,7 +81,7 @@ namespace ShiftPlanner
             Controls.Add(btnRemove);
             Controls.Add(btnOk);
             Controls.Add(btnCancel);
-            FormBorderStyle = FormBorderStyle.FixedDialog;
+            FormBorderStyle = FormBorderStyle.Sizable;
             StartPosition = FormStartPosition.CenterParent;
             Text = "勤務時間マスター";
 

--- a/ShiftPlanner/ShiftTimeMasterForm.cs
+++ b/ShiftPlanner/ShiftTimeMasterForm.cs
@@ -98,6 +98,10 @@ namespace ShiftPlanner
                         break;
                 }
             }
+
+            // 列幅をフォームのサイズに合わせて調整
+            DataGridViewHelper.SetColumnsNotSortable(dtShiftTimes);
+            DataGridViewHelper.FitColumnsToGrid(dtShiftTimes);
         }
 
         private void DtShiftTimes_CellFormatting(object? sender, DataGridViewCellFormattingEventArgs e)

--- a/ShiftPlanner/SkillGroupMasterForm.Designer.cs
+++ b/ShiftPlanner/SkillGroupMasterForm.Designer.cs
@@ -81,7 +81,7 @@ namespace ShiftPlanner
             Controls.Add(btnRemove);
             Controls.Add(btnOk);
             Controls.Add(btnCancel);
-            FormBorderStyle = FormBorderStyle.FixedDialog;
+            FormBorderStyle = FormBorderStyle.Sizable;
             StartPosition = FormStartPosition.CenterParent;
             Text = "スキルグループマスター";
 

--- a/ShiftPlanner/SkillGroupMasterForm.cs
+++ b/ShiftPlanner/SkillGroupMasterForm.cs
@@ -70,6 +70,10 @@ namespace ShiftPlanner
                         break;
                 }
             }
+
+            // 列幅をフォームのサイズに合わせて調整
+            DataGridViewHelper.SetColumnsNotSortable(dtSkillGroups);
+            DataGridViewHelper.FitColumnsToGrid(dtSkillGroups);
         }
     }
 }


### PR DESCRIPTION
## 変更内容
- DataGridViewHelper に列幅をフォーム幅へ合わせる `FitColumnsToGrid` を追加
- 各マスター画面とメイン画面で `FitColumnsToGrid` を呼び出し、スクロール無しで表示できるよう調整
- マスター系フォームの `FormBorderStyle` を `Sizable` へ変更し、ウィンドウサイズ変更に追随

## テスト
- `dotnet` コマンドが利用できない環境のためビルドは未実施

------
https://chatgpt.com/codex/tasks/task_e_684ccf8e9e9c83339d2c08be03f63ce3