### PR TITLE
DataGridViewのデータエラー処理を追加

### DIFF
--- a/ShiftPlanner/MemberMasterForm.cs
+++ b/ShiftPlanner/MemberMasterForm.cs
@@ -209,6 +209,8 @@ namespace ShiftPlanner
             dtMembers.CellFormatting += DtMembers_CellFormatting;
             dtMembers.CellParsing += DtMembers_CellParsing;
             dtMembers.CurrentCellDirtyStateChanged += DtMembers_CurrentCellDirtyStateChanged;
+            // データエラー時に独自メッセージを表示する
+            dtMembers.DataError += DtMembers_DataError;
             DataGridViewHelper.SetColumnsNotSortable(dtMembers);
             // フォームサイズに合わせて列幅を自動調整
             DataGridViewHelper.FitColumnsToGrid(dtMembers);
@@ -357,6 +359,19 @@ namespace ShiftPlanner
                     e.ParsingApplied = true;
                 }
             }
+        }
+
+        /// <summary>
+        /// DataGridViewのデータエラーを処理します。
+        /// </summary>
+        private void DtMembers_DataError(object? sender, DataGridViewDataErrorEventArgs e)
+        {
+            // 既定の例外ダイアログを抑制
+            e.ThrowException = false;
+
+            // 例外メッセージが取得できない場合も考慮
+            string message = e.Exception?.Message ?? "データ形式が正しくありません。";
+            MessageBox.Show($"入力値に誤りがあります: {message}", "データエラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
         }
 
         /// <summary>


### PR DESCRIPTION
## 変更内容
- メンバー編集画面(`MemberMasterForm`)で `DataError` イベントをハンドルし、入力値に問題がある際の例外ダイアログを独自メッセージに置き換えました
- イベント登録を `SetupMemberGrid` 内に追加しました

## テスト
- `dotnet build` を実行しましたが .NET Framework 4.8 の参照アセンブリが不足しているためビルドに失敗しました
- `xbuild` を試行しましたが C# 8.0 をサポートしておらずビルドできませんでした

------
https://chatgpt.com/codex/tasks/task_e_684cde414bd883338a7ef7564a4018e9