### PR TITLE
メンバー編集画面のスキルグループエラーを修正

### DIFF
--- a/ShiftPlanner/MemberMasterForm.cs
+++ b/ShiftPlanner/MemberMasterForm.cs
@@ -98,12 +98,26 @@ namespace ShiftPlanner
             {
                 int index = sgCol.Index;
                 dtMembers.Columns.Remove(sgCol);
+
+                // スキルグループはメンバー側に存在する値も含めてリスト化
+                var sgList = _skillGroups?.Select(g => g.Name).ToList() ?? new List<string>();
+                var memberGroups = _members.Where(m => !string.IsNullOrEmpty(m.SkillGroup))
+                                           .Select(m => m.SkillGroup);
+                foreach (var g in memberGroups)
+                {
+                    if (!sgList.Contains(g))
+                    {
+                        sgList.Add(g);
+                    }
+                }
+
                 var combo = new DataGridViewComboBoxColumn
                 {
                     Name = nameof(Member.SkillGroup),
                     DataPropertyName = nameof(Member.SkillGroup),
-                    DataSource = _skillGroups?.Select(g => g.Name).ToList() ?? new List<string>(),
-                    HeaderText = "スキルグループ"
+                    DataSource = sgList,
+                    HeaderText = "スキルグループ",
+                    DisplayStyleForCurrentCellOnly = true
                 };
                 dtMembers.Columns.Insert(index, combo);
             }


### PR DESCRIPTION
## 概要
スキルグループが未登録の状態でメンバー編集画面を開くと、
`DataGridViewComboBoxColumn` が空のデータソースを持つため `DataError` が発生していました。
既存メンバーに設定されているスキルグループ名をリストへ補完し、
コンボボックスの表示スタイルを調整することでエラーを回避します。

## 変更点
- `MemberMasterForm.SetupMemberGrid` でスキルグループ列のデータソース生成を改善
  - メンバーが持つスキルグループ名も含めてリスト化
  - `DisplayStyleForCurrentCellOnly` を設定して見た目を改善

## テスト
- `dotnet build` は環境に `dotnet` が存在しないため実行できず
  ```
  bash: dotnet: command not found
  ```
  ビルド確認は行えていません。

------
https://chatgpt.com/codex/tasks/task_e_684ce1c3cc648333b1b6c2418f19bea1