### PR TITLE
GUIの表示負荷軽減のためのリサイズ処理修正

### DIFF
--- a/ShiftPlanner/MainForm.Designer.cs
+++ b/ShiftPlanner/MainForm.Designer.cs
@@ -125,13 +125,15 @@ namespace ShiftPlanner
             // dtShifts
             //
             this.dtShifts.AllowUserToAddRows = false;
-            this.dtShifts.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
-            | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right));
+            // グリッドサイズは固定とするためアンカーをTopとLeftのみに設定
+            this.dtShifts.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
             this.dtShifts.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dtShifts.Location = new System.Drawing.Point(6, 38);
             this.dtShifts.Name = "dtShifts";
             this.dtShifts.RowTemplate.Height = 21;
             this.dtShifts.Size = new System.Drawing.Size(1373, 764);
+            // 非表示部分はスクロールして閲覧できるようにする
+            this.dtShifts.ScrollBars = System.Windows.Forms.ScrollBars.Both;
             this.dtShifts.TabIndex = 1;
             //
             // cmbDefaultRequired


### PR DESCRIPTION
## Summary
- シフトタブ内の`DataGridView`サイズを固定し、スクロールバーを表示
- フォームリサイズ時に`DataGridView`を再描画しないようアンカー設定を変更

## Testing
- `dotnet --version` *(失敗: `dotnet` コマンドが存在せず)*


------
https://chatgpt.com/codex/tasks/task_e_684ce92a63788333b0ded466d707e978