### PR TITLE
DataGridViewのパース処理を修正

### DIFF
--- a/ShiftPlanner/MemberMasterForm.cs
+++ b/ShiftPlanner/MemberMasterForm.cs
@@ -323,6 +323,8 @@ namespace ShiftPlanner
                         }
                     }
 
+                    // DataGridView に設定する値も更新しておく
+                    e.Value = val;
                     e.ParsingApplied = true;
                 }
             }
@@ -353,6 +355,8 @@ namespace ShiftPlanner
                         m.AvailableShiftNames?.Remove(shiftName);
                     }
 
+                    // 入力値を DataGridView に反映
+                    e.Value = val;
                     e.ParsingApplied = true;
                 }
             }
@@ -365,11 +369,15 @@ namespace ShiftPlanner
                         m.Constraints = new ShiftConstraints();
                     }
 
-                    if (e.Value != null && int.TryParse(e.Value.ToString(), out int value))
+                    int value = 0;
+                    if (e.Value != null && int.TryParse(e.Value.ToString(), out int parsed))
                     {
+                        value = parsed;
                         m.Constraints.MaxConsecutiveDays = value;
                     }
 
+                    // DataGridView 側にも数値を設定
+                    e.Value = value;
                     e.ParsingApplied = true;
                 }
             }


### PR DESCRIPTION
## 概要
- MemberMasterForm の CellParsing イベントで `e.Value` を設定していなかったため、型変換エラーが発生していました
- 解析後の値を `e.Value` に戻すよう修正し、DataGridView 側でも正しい値が保持されるようにしました

## 変更内容
- `Day_*` 列、`Shift_*` 列、`連続勤務上限` 列のパース処理で `e.Value` を更新
- これにより無効な値入力時の "セルのフォーマットされた値に間違った型" エラーを回避

## テスト
- `dotnet build` を実行し、ビルドエラーがないことを確認


------
https://chatgpt.com/codex/tasks/task_e_684cebdf84148333b6fc7dc6a2266a0e