### PR TITLE
メンバー一覧グリッドの列設定修正

### DIFF
--- a/ShiftPlanner/MemberMasterForm.cs
+++ b/ShiftPlanner/MemberMasterForm.cs
@@ -142,14 +142,22 @@ namespace ShiftPlanner
                         // この列は後で曜日ごとのチェックボックス列に置き換えるため非表示
                         col.Visible = false;
                         break;
+                    case nameof(Member.AvailableShiftNames):
+                        // List 型列は直接編集しないため非表示
+                        col.Visible = false;
+                        break;
                     case nameof(Member.Skills):
                         col.HeaderText = "スキル";
+                        // List 型列は直接編集しないため読み取り専用とする
+                        col.ReadOnly = true;
                         break;
                     case nameof(Member.SkillGroup):
                         col.HeaderText = "スキルグループ";
                         break;
                     case nameof(Member.DesiredHolidays):
                         col.HeaderText = "希望休";
+                        // List 型列は直接編集しないため読み取り専用とする
+                        col.ReadOnly = true;
                         break;
                     case nameof(Member.Constraints):
                         col.Visible = false;


### PR DESCRIPTION
## 変更内容
- `MemberMasterForm.SetupMemberGrid` の列設定を更新
  - `Member.AvailableShiftNames` 列を非表示に
  - `Member.Skills` 列を読み取り専用化
  - `Member.DesiredHolidays` 列を読み取り専用化
  - List 型列は直接編集しない旨をコメント追加

## 動作確認
- `dotnet build` を試みましたが、環境に `dotnet` コマンドが存在せずビルドできませんでした

------
https://chatgpt.com/codex/tasks/task_e_684cf2027ea883339eca4e8bf5d86b4a