### PR TITLE
メンバー編集画面の勤務時間列追加処理を修正

### DIFF
--- a/ShiftPlanner/MemberMasterForm.cs
+++ b/ShiftPlanner/MemberMasterForm.cs
@@ -205,7 +205,8 @@ namespace ShiftPlanner
             // 出勤時間ごとの可否チェック列を追加
             foreach (var st in _shiftTimes)
             {
-                if (st == null || !st.IsEnabled)
+                // null チェックも兼ねて有効な勤務時間のみ追加
+                if (st?.IsEnabled != true)
                 {
                     // 無効な勤務時間は表示しない
                     continue;


### PR DESCRIPTION
## 変更内容
- 勤務時間列を追加する際に `null` と無効フラグを同時に確認するよう修正
- その他の既存コードはそのまま

## 動作確認
- `ShiftTime.IsEnabled` プロパティと `DataGridViewHelper.FitColumnsToGrid` メソッドの実装を確認
- ビルドコマンドは環境上利用不可のため未実行

------
https://chatgpt.com/codex/tasks/task_e_684cf2b7c38c83338866aaa4429a67f3