### PR TITLE
メンバーマスターの連続勤務上限機能を削除

### DIFF
--- a/ShiftPlanner/MemberMasterForm.cs
+++ b/ShiftPlanner/MemberMasterForm.cs
@@ -15,11 +15,6 @@ namespace ShiftPlanner
         private readonly List<SkillGroup> _skillGroups;
         private readonly List<ShiftTime> _shiftTimes;
 
-        /// <summary>
-        /// 連続勤務上限を表示する列名
-        /// </summary>
-        private const string ColMaxConsecutive = "MaxConsecutiveDays";
-
         public MemberMasterForm(List<Member> members, List<SkillGroup> skillGroups, List<ShiftTime> shiftTimes)
         {
             _members = new BindingList<Member>(members ?? new List<Member>());
@@ -50,15 +45,6 @@ namespace ShiftPlanner
                 WorksOnSunday = true
             };
 
-            // 連続勤務上限が未設定であれば 5 日を設定
-            if (member.Constraints == null)
-            {
-                member.Constraints = new ShiftConstraints();
-            }
-            if (member.Constraints.MaxConsecutiveDays <= 0)
-            {
-                member.Constraints.MaxConsecutiveDays = 5;
-            }
 
             try
             {
@@ -173,19 +159,6 @@ namespace ShiftPlanner
                 }
             }
 
-            // 連続勤務上限を編集する列を追加
-            if (!dtMembers.Columns.Contains(ColMaxConsecutive))
-            {
-                var maxCol = new DataGridViewTextBoxColumn
-                {
-                    Name = ColMaxConsecutive,
-                    HeaderText = "連続勤務上限",
-                    DataPropertyName = string.Empty,
-                    Width = 60
-                };
-                dtMembers.Columns.Add(maxCol);
-            }
-
             // 曜日ごとの勤務可否チェック列を追加
             var days = Enum.GetValues(typeof(DayOfWeek))
                 .Cast<DayOfWeek>()
@@ -275,14 +248,6 @@ namespace ShiftPlanner
                     e.FormattingApplied = true;
                 }
             }
-            else if (column != null && column.Name == ColMaxConsecutive)
-            {
-                if (dtMembers.Rows[e.RowIndex].DataBoundItem is Member m)
-                {
-                    e.Value = m.Constraints?.MaxConsecutiveDays;
-                    e.FormattingApplied = true;
-                }
-            }
         }
 
         private void DtMembers_CellParsing(object? sender, DataGridViewCellParsingEventArgs e)
@@ -366,27 +331,6 @@ namespace ShiftPlanner
 
                     // 入力値を DataGridView に反映
                     e.Value = val;
-                    e.ParsingApplied = true;
-                }
-            }
-            else if (column != null && column.Name == ColMaxConsecutive)
-            {
-                if (dtMembers.Rows[e.RowIndex].DataBoundItem is Member m)
-                {
-                    if (m.Constraints == null)
-                    {
-                        m.Constraints = new ShiftConstraints();
-                    }
-
-                    int value = 0;
-                    if (e.Value != null && int.TryParse(e.Value.ToString(), out int parsed))
-                    {
-                        value = parsed;
-                        m.Constraints.MaxConsecutiveDays = value;
-                    }
-
-                    // DataGridView 側にも数値を設定
-                    e.Value = value;
                     e.ParsingApplied = true;
                 }
             }


### PR DESCRIPTION
## 変更内容
- メンバーマスターで連続勤務上限列を生成していた処理を削除
- 追加時の連続勤務上限初期化処理を削除
- セルフォーマット・パース処理から連続勤務上限関連ロジックを削除

## テスト
- `dotnet build` を試みたが `dotnet` コマンドが存在せず実行できず

------
https://chatgpt.com/codex/tasks/task_e_684cf517ff608333862844442f7af5ba