### PR TITLE
シフト表行読み込みロジック改善

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -1592,13 +1592,35 @@ namespace ShiftPlanner
                         return;
                     }
 
-                    int rows = Math.Min(data.Count, shiftTable.Rows.Count);
-                    for (int r = 0; r < rows; r++)
+                    // 1列目の値をキーとした辞書に変換
+                    var rowMap = new Dictionary<string, List<string>>();
+                    foreach (var row in data)
                     {
-                        int cols = Math.Min(data[r].Count, shiftTable.Columns.Count);
-                        for (int c = 0; c < cols; c++)
+                        if (row == null || row.Count == 0)
                         {
-                            shiftTable.Rows[r][c] = data[r][c];
+                            continue;
+                        }
+
+                        var key = row[0] ?? string.Empty;
+                        if (!rowMap.ContainsKey(key))
+                        {
+                            rowMap[key] = row;
+                        }
+                    }
+
+                    // 現在のテーブルの行名を基にデータを上書き
+                    foreach (DataRow row in shiftTable.Rows)
+                    {
+                        var name = row[0]?.ToString() ?? string.Empty;
+                        if (!rowMap.TryGetValue(name, out var savedRow))
+                        {
+                            continue; // 保存データに該当行がなければスキップ
+                        }
+
+                        int cols = Math.Min(savedRow.Count, shiftTable.Columns.Count);
+                        for (int c = 1; c < cols; c++)
+                        {
+                            row[c] = savedRow[c];
                         }
                     }
                 }


### PR DESCRIPTION
## 概要
- `LoadShiftTable` で保存済みシフト表の行名と突き合わせるよう変更し、メンバー追加後でも行順が崩れないようにしました
- 既存の行名に一致する場合のみ保存データを反映するため、不要な行が読み込まれません

## 変更理由
メンバー追加後にシフト表更新を行うと、"必要人数" 行が途中に表示されたり、過去のメンバー行が残存する問題がありました。行名をキーに読み込むことで常に最新のメンバー構成に合わせた表示ができます。

## テスト
- `dotnet build ShiftPlanner.sln` を実行しようとしましたが、.NET Framework 4.8 の参照アセンブリが無いためビルドエラーとなりました

------
https://chatgpt.com/codex/tasks/task_e_684cf6e1abcc8333b0a84f272df887c1