### PR TITLE
メンバー追加時のシフト初期値を改善

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -803,10 +803,20 @@ namespace ShiftPlanner
         {
             var nextId = members.Count > 0 ? members.Max(m => m.Id) + 1 : 1;
 
+            // 新規メンバー作成時は全曜日かつ全勤務時間帯を選択可能とする
             var member = new Member
             {
                 Id = nextId,
                 Name = "新規",
+                AvailableDays = Enum.GetValues(typeof(DayOfWeek))
+                    .Cast<DayOfWeek>()
+                    .ToList(),
+                WorksOnSaturday = true,
+                WorksOnSunday = true,
+                AvailableShiftNames = shiftTimes?
+                    .Where(st => st != null && st.IsEnabled)
+                    .Select(st => st.Name)
+                    .ToList() ?? new List<string>()
             };
 
             // 連続勤務上限が未設定であれば 5 日を設定


### PR DESCRIPTION
## 変更内容
- メイン画面でメンバー追加時、全曜日・全勤務時間帯を初期選択するよう修正
- これにより追加直後にシフト更新を行っても休みにならないように改善

## テスト
- `dotnet build` を試みましたが、環境に `dotnet` コマンドが存在せずビルドできませんでした

------
https://chatgpt.com/codex/tasks/task_e_684cf90176b48333bae61f5ad6611036