### PR TITLE
シフト表の表示改善

### DIFF
--- a/ShiftPlanner/DataGridViewHelper.cs
+++ b/ShiftPlanner/DataGridViewHelper.cs
@@ -56,5 +56,33 @@ namespace ShiftPlanner
             // 利用可能な領域で列幅を均等に調整
             grid.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill;
         }
+
+        /// <summary>
+        /// 指定した列幅を設定します。
+        /// </summary>
+        /// <param name="grid">対象の DataGridView</param>
+        /// <param name="columnIndex">列インデックス</param>
+        /// <param name="width">幅</param>
+        public static void SetColumnWidth(DataGridView? grid, int columnIndex, int width)
+        {
+            if (grid?.Columns == null)
+            {
+                return;
+            }
+
+            if (columnIndex < 0 || columnIndex >= grid.Columns.Count)
+            {
+                return;
+            }
+
+            var column = grid.Columns[columnIndex];
+            if (column == null)
+            {
+                return;
+            }
+
+            column.AutoSizeMode = DataGridViewAutoSizeColumnMode.None;
+            column.Width = width;
+        }
     }
 }

--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -1210,6 +1210,8 @@ namespace ShiftPlanner
             // 列幅をヘッダー表示に合わせて調整
             DataGridViewHelper.AdjustColumnWidthToHeader(dtShifts);
             DataGridViewHelper.FitColumnsToGrid(dtShifts);
+            // メンバー名列の幅を固定
+            DataGridViewHelper.SetColumnWidth(dtShifts, 0, 120);
 
             dtShifts.CellFormatting -= DtShifts_CellFormatting;
             dtShifts.CellFormatting += DtShifts_CellFormatting;
@@ -1248,7 +1250,18 @@ namespace ShiftPlanner
                 var reqRow = shiftTable.Rows[shiftTable.Rows.Count - 2];
                 int.TryParse(reqRow[e.ColumnIndex]?.ToString(), out int req);
                 int.TryParse(shiftTable.Rows[e.RowIndex][e.ColumnIndex]?.ToString(), out int actual);
-                e.CellStyle.BackColor = req == actual ? Color.LightBlue : Color.LightPink;
+                if (req == actual)
+                {
+                    e.CellStyle.BackColor = Color.LightBlue;
+                }
+                else if (actual < req)
+                {
+                    e.CellStyle.BackColor = Color.Red;
+                }
+                else
+                {
+                    e.CellStyle.BackColor = Color.LightGreen;
+                }
             }
             else if (shiftTable.Rows[e.RowIndex][0].ToString() != "必要人数")
             {
@@ -1257,7 +1270,13 @@ namespace ShiftPlanner
                 if (!string.IsNullOrEmpty(val))
                 {
                     string name = val.StartsWith("希") ? val.Substring(1) : val;
-                    if (!string.IsNullOrEmpty(name) && name != "休")
+                    if (val == "希休")
+                    {
+                        // 希望休は赤字で表示
+                        e.CellStyle.ForeColor = Color.Red;
+                        e.CellStyle.BackColor = Color.LightGray;
+                    }
+                    else if (!string.IsNullOrEmpty(name) && name != "休")
                     {
                         var st = shiftTimes.FirstOrDefault(s => s.Name == name);
                         if (st != null)


### PR DESCRIPTION
## 変更内容
- DataGridViewHelper に列幅を指定できる `SetColumnWidth` メソッドを追加
- シフト表表示時にメンバー名列の幅を固定し、名前が見やすいよう調整
- 出勤人数行の色分けを不足時赤、過剰時緑、条件一致時は従来色に変更
- 希望休セルの文字色を赤に変更

## 確認事項
- `dotnet` コマンドが存在しないためビルドは未実施


------
https://chatgpt.com/codex/tasks/task_e_684cfb223ff48333988d684bcde6ede1