### PR TITLE
シフト時間変更時のエラー修正

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -1016,7 +1016,9 @@ namespace ShiftPlanner
                     NormalizeMemberShiftNames();
                     SaveShiftTimes();
                     SaveMembers();
-                    SetupShiftGrid();
+                    // 勤務時間マスター変更時はシフト表の内容を一旦クリア
+                    SetupShiftGrid(false);
+                    SaveShiftTable();
                 }
             }
         }
@@ -1181,7 +1183,11 @@ namespace ShiftPlanner
         /// <summary>
         /// シフト表のグリッドを作成します。
         /// </summary>
-        private void SetupShiftGrid()
+        /// <summary>
+        /// シフト表のグリッドを作成します。
+        /// </summary>
+        /// <param name="loadSavedData">保存済みシフト表を読み込むかどうか</param>
+        private void SetupShiftGrid(bool loadSavedData = true)
         {
             if (dtShifts == null || dtp対象月 == null)
             {
@@ -1280,7 +1286,10 @@ namespace ShiftPlanner
             dtShifts.EditingControlShowing -= DtShifts_EditingControlShowing;
             dtShifts.EditingControlShowing += DtShifts_EditingControlShowing;
 
-            LoadShiftTable();
+            if (loadSavedData)
+            {
+                LoadShiftTable();
+            }
             UpdateAttendanceCounts();
         }
 


### PR DESCRIPTION
## 変更内容
- 勤務時間マスター編集後にシフト表を再構築する際、保存済みのシフト表を読み込まず初期化するよう修正
- `SetupShiftGrid` メソッドに保存データを読み込むかどうかを指定する引数を追加
- 勤務時間マスター編集時にシフト表をクリアして保存

## 確認したこと
- `dotnet build` を試行しましたが、環境に `dotnet` コマンドが存在しないためビルドできませんでした


------
https://chatgpt.com/codex/tasks/task_e_684d0671ca648333bdc47144f30dd20e