### PR TITLE
Fix missing compile item

### DIFF
--- a/ShiftPlanner/ShiftPlanner.csproj
+++ b/ShiftPlanner/ShiftPlanner.csproj
@@ -84,6 +84,8 @@
     <Compile Include="ShiftAnalyzer.cs" />
     <Compile Include="ShiftAssignment.cs" />
     <Compile Include="ShiftGenerator.cs" />
+    <!-- 貪欲法によるシフト自動生成 -->
+    <Compile Include="ShiftGeneratorGreedy.cs" />
     <Compile Include="JapaneseHolidayHelper.cs" />
     <Compile Include="CustomHoliday.cs" />
     <!-- DataGridView の拡張メソッド -->


### PR DESCRIPTION
## Summary
- csproj に ShiftGeneratorGreedy.cs を追加

## Testing
- `dotnet build ShiftPlanner.sln -c Release` *(fails: reference assemblies for .NETFramework not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d33a39e8c8333b4824ccd4c1ea782