### PR TITLE
出勤人数計算ロジック修正

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -1310,8 +1310,11 @@ namespace ShiftPlanner
             // 出勤人数行の色付け
             if (shiftTable.Rows[e.RowIndex][0].ToString() == "出勤人数")
             {
+                // 勤務時間マスタの必要人数のみを合計する
                 int required = 0;
-                for (int r = members.Count; r < shiftTable.Rows.Count - 1; r++)
+                int startRow = members.Count + skillGroups.Count;
+                int endRow = startRow + enabledShiftTimes.Count;
+                for (int r = startRow; r < endRow; r++)
                 {
                     int.TryParse(shiftTable.Rows[r][e.ColumnIndex]?.ToString(), out int v);
                     required += v;


### PR DESCRIPTION
## 概要
勤務時間マスタの必要人数のみを合計して出勤人数を算出するように修正しました。

## 変更点
- `DtShifts_CellFormatting` 内で出勤人数行の必要人数集計範囲を勤務時間マスタの行のみに変更
- コメントを追加し処理内容を明確化

## 動作確認
- `dotnet` コマンドが利用できないためビルドは未実施

------
https://chatgpt.com/codex/tasks/task_e_684d374f644c8333ac138cf064c18f3d