### PR TITLE
勤怠行の実人数に応じた色付けを追加

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -1334,6 +1334,41 @@ namespace ShiftPlanner
                     e.CellStyle.BackColor = Color.LightGreen;
                 }
             }
+            // 勤怠時間ごとの必要人数行の色付け
+            else if (e.RowIndex >= members.Count + skillGroups.Count &&
+                     e.RowIndex < members.Count + skillGroups.Count + enabledShiftTimes.Count)
+            {
+                string? shiftName = shiftTable.Rows[e.RowIndex][0]?.ToString();
+                if (!string.IsNullOrEmpty(shiftName))
+                {
+                    // その日の実際の割り当て人数を数える
+                    int actual = 0;
+                    for (int r = 0; r < members.Count; r++)
+                    {
+                        string val = shiftTable.Rows[r][e.ColumnIndex]?.ToString() ?? string.Empty;
+                        string name = val.StartsWith("希") ? val.Substring(1) : val;
+                        if (name == shiftName)
+                        {
+                            actual++;
+                        }
+                    }
+
+                    int.TryParse(shiftTable.Rows[e.RowIndex][e.ColumnIndex]?.ToString(), out int required);
+
+                    if (actual == required)
+                    {
+                        e.CellStyle.BackColor = Color.LightBlue;
+                    }
+                    else if (actual < required)
+                    {
+                        e.CellStyle.BackColor = Color.Red;
+                    }
+                    else
+                    {
+                        e.CellStyle.BackColor = Color.LightGreen;
+                    }
+                }
+            }
             else if (e.RowIndex < members.Count)
             {
                 // メンバー行の色付け


### PR DESCRIPTION
## 変更内容
- `DtShifts_CellFormatting` に勤怠時間行の判定を追加し、必要人数と実人数を比較して色分けする機能を実装しました。
- 実人数が不足している場合は赤、丁度の場合は水色、超過している場合は緑で表示されます。

## テスト
- `dotnet build` を試みましたが、環境に `dotnet` コマンドが存在せずビルドできませんでした。

------
https://chatgpt.com/codex/tasks/task_e_684d6a26dc988333949dfc022cb030af