### PR TITLE
休み数セルの視覚的な警告を追加

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -1299,7 +1299,30 @@ namespace ShiftPlanner
         /// </summary>
         private void DtShifts_CellFormatting(object? sender, DataGridViewCellFormattingEventArgs e)
         {
-            if (dtShifts == null || dtp対象月 == null || e.ColumnIndex < dateColumnStartIndex || e.RowIndex < 0)
+            if (dtShifts == null || dtp対象月 == null || e.RowIndex < 0)
+            {
+                return;
+            }
+
+            // 休み数列の色付け判定
+            int restColumnIndex = 1 + enabledShiftTimes.Count;
+            if (e.ColumnIndex == restColumnIndex && e.RowIndex < members.Count)
+            {
+                if (int.TryParse(shiftTable.Rows[e.RowIndex][e.ColumnIndex]?.ToString(), out int restCount))
+                {
+                    if (restCount < minHolidayCount)
+                    {
+                        e.CellStyle.BackColor = Color.Red;
+                    }
+                    else if (restCount > minHolidayCount)
+                    {
+                        e.CellStyle.BackColor = Color.LightGreen;
+                    }
+                }
+                return;
+            }
+
+            if (e.ColumnIndex < dateColumnStartIndex)
             {
                 return;
             }


### PR DESCRIPTION
## 概要
- `DtShifts_CellFormatting` 内で休み集計列の色付けを追加
- 最低休日日数より少ない場合は赤、超えた場合は薄緑で表示する

## テスト
- `dotnet` コマンドが存在しないためビルドは行えず

------
https://chatgpt.com/codex/tasks/task_e_684d79c867cc83338ecc4dab03eb2696