### PR TITLE
不要となったデフォルト人数設定の除去

### DIFF
--- a/ShiftPlanner/AppSettings.cs
+++ b/ShiftPlanner/AppSettings.cs
@@ -11,9 +11,6 @@ namespace ShiftPlanner
         [DataMember]
         public int HolidayLimit { get; set; } = 3;
 
-        [DataMember]
-        public int DefaultRequired { get; set; } = 1;
-
         /// <summary>
         /// メンバーごとの最低休日日数
         /// </summary>

--- a/ShiftPlanner/MainForm.Designer.cs
+++ b/ShiftPlanner/MainForm.Designer.cs
@@ -19,8 +19,6 @@ namespace ShiftPlanner
         private DataGridView dtRequestSummary;
         private ComboBox cmbHolidayLimit;
         private Label lblHolidayLimit;
-        private ComboBox cmbDefaultRequired;
-        private Label lblDefaultRequired;
         private ComboBox cmbMinHolidayCount;
         private Label lblMinHolidayCount;
         private Button btnAddRequest;
@@ -65,8 +63,6 @@ namespace ShiftPlanner
             this.btnAddRequest = new System.Windows.Forms.Button();
             this.cmbHolidayLimit = new System.Windows.Forms.ComboBox();
             this.lblHolidayLimit = new System.Windows.Forms.Label();
-            this.cmbDefaultRequired = new System.Windows.Forms.ComboBox();
-            this.lblDefaultRequired = new System.Windows.Forms.Label();
             this.cmbMinHolidayCount = new System.Windows.Forms.ComboBox();
             this.lblMinHolidayCount = new System.Windows.Forms.Label();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
@@ -111,8 +107,6 @@ namespace ShiftPlanner
             this.tabShift.Controls.Add(this.dtShifts);
             this.tabShift.Controls.Add(this.cmbMinHolidayCount);
             this.tabShift.Controls.Add(this.lblMinHolidayCount);
-            this.tabShift.Controls.Add(this.cmbDefaultRequired);
-            this.tabShift.Controls.Add(this.lblDefaultRequired);
             this.tabShift.Controls.Add(this.btnShiftGenerate);
             this.tabShift.Location = new System.Drawing.Point(4, 22);
             this.tabShift.Name = "tabShift";
@@ -136,27 +130,6 @@ namespace ShiftPlanner
             this.dtShifts.ScrollBars = System.Windows.Forms.ScrollBars.Both;
             this.dtShifts.TabIndex = 1;
             //
-            // cmbDefaultRequired
-            //
-            this.cmbDefaultRequired.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbDefaultRequired.FormattingEnabled = true;
-            this.cmbDefaultRequired.Items.AddRange(new object[] {
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10"});
-            this.cmbDefaultRequired.Location = new System.Drawing.Point(200, 8);
-            this.cmbDefaultRequired.Name = "cmbDefaultRequired";
-            this.cmbDefaultRequired.Size = new System.Drawing.Size(60, 20);
-            this.cmbDefaultRequired.TabIndex = 3;
-            this.cmbDefaultRequired.SelectedIndexChanged += new System.EventHandler(this.CmbDefaultRequired_SelectedIndexChanged);
-            //
             // cmbMinHolidayCount
             //
             this.cmbMinHolidayCount.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
@@ -178,15 +151,6 @@ namespace ShiftPlanner
             this.cmbMinHolidayCount.Size = new System.Drawing.Size(60, 20);
             this.cmbMinHolidayCount.TabIndex = 5;
             this.cmbMinHolidayCount.SelectedIndexChanged += new System.EventHandler(this.CmbMinHolidayCount_SelectedIndexChanged);
-            //
-            // lblDefaultRequired
-            //
-            this.lblDefaultRequired.AutoSize = true;
-            this.lblDefaultRequired.Location = new System.Drawing.Point(110, 11);
-            this.lblDefaultRequired.Name = "lblDefaultRequired";
-            this.lblDefaultRequired.Size = new System.Drawing.Size(84, 12);
-            this.lblDefaultRequired.TabIndex = 2;
-            this.lblDefaultRequired.Text = "必要人数デフォルト";
             //
             // lblMinHolidayCount
             //

--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -137,11 +137,6 @@ namespace ShiftPlanner
                 holidayLimit = settings.HolidayLimit;
             }
 
-            if (cmbDefaultRequired != null)
-            {
-                cmbDefaultRequired.SelectedItem = settings.DefaultRequired.ToString();
-            }
-
             if (cmbMinHolidayCount != null)
             {
                 cmbMinHolidayCount.SelectedItem = settings.MinHolidayCount.ToString();
@@ -1084,29 +1079,6 @@ namespace ShiftPlanner
             UpdateRequestSummary();
         }
 
-        private void CmbDefaultRequired_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (!int.TryParse(cmbDefaultRequired?.SelectedItem?.ToString(), out int v))
-            {
-                return;
-            }
-
-            settings.DefaultRequired = v;
-            SaveSettings();
-
-            int reqStart = members.Count;
-            int reqEnd = shiftTable.Rows.Count - 1; // 出勤人数行以外
-            for (int row = reqStart; row < reqEnd; row++)
-            {
-                for (int col = 1; col < shiftTable.Columns.Count; col++)
-                {
-                    shiftTable.Rows[row][col] = v;
-                }
-            }
-            UpdateAttendanceCounts();
-            // 保存処理はバックグラウンドで実行し、UI の応答性を確保
-            SaveShiftTableAsync();
-        }
 
         private void CmbMinHolidayCount_SelectedIndexChanged(object sender, EventArgs e)
         {
@@ -1239,7 +1211,7 @@ namespace ShiftPlanner
                 row[0] = sg.Name;
                 for (int i = 1; i < shiftTable.Columns.Count; i++)
                 {
-                    row[i] = settings.DefaultRequired;
+                    row[i] = 0; // 新規作成行は 0 で初期化
                 }
                 shiftTable.Rows.Add(row);
             }
@@ -1251,7 +1223,7 @@ namespace ShiftPlanner
                 row[0] = st.Name;
                 for (int i = 1; i < shiftTable.Columns.Count; i++)
                 {
-                    row[i] = settings.DefaultRequired;
+                    row[i] = 0; // 新規作成行は 0 で初期化
                 }
                 shiftTable.Rows.Add(row);
             }


### PR DESCRIPTION
## 変更内容
- `AppSettings` から `DefaultRequired` プロパティを削除
- `MainForm.Designer` から `cmbDefaultRequired` と `lblDefaultRequired` の定義および配置コードを削除
- `MainForm` 内の `cmbDefaultRequired` 関連処理を撤去
- シフト表生成時、新規行の必要人数初期値を `0` に変更

## テスト
- `dotnet build` を試行したが、環境に `dotnet` コマンドが無くビルド不可

------
https://chatgpt.com/codex/tasks/task_e_684d79c774248333bc0735177a80b520