### PR TITLE
集計ボタンの表示修正

### DIFF
--- a/ShiftPlanner/MainForm.Designer.cs
+++ b/ShiftPlanner/MainForm.Designer.cs
@@ -23,6 +23,7 @@ namespace ShiftPlanner
         private Label lblDefaultRequired;
         private ComboBox cmbMinHolidayCount;
         private Label lblMinHolidayCount;
+        private Button btnAggregate;
         private Button btnAddRequest;
         private Button btnRemoveRequest;
         private DateTimePicker dtp分析月;
@@ -69,6 +70,7 @@ namespace ShiftPlanner
             this.lblDefaultRequired = new System.Windows.Forms.Label();
             this.cmbMinHolidayCount = new System.Windows.Forms.ComboBox();
             this.lblMinHolidayCount = new System.Windows.Forms.Label();
+            this.btnAggregate = new System.Windows.Forms.Button();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.menuFile = new System.Windows.Forms.ToolStripMenuItem();
             this.menuExportAnalysisCsv = new System.Windows.Forms.ToolStripMenuItem();
@@ -113,6 +115,7 @@ namespace ShiftPlanner
             this.tabShift.Controls.Add(this.lblMinHolidayCount);
             this.tabShift.Controls.Add(this.cmbDefaultRequired);
             this.tabShift.Controls.Add(this.lblDefaultRequired);
+            this.tabShift.Controls.Add(this.btnAggregate);
             this.tabShift.Controls.Add(this.btnShiftGenerate);
             this.tabShift.Location = new System.Drawing.Point(4, 22);
             this.tabShift.Name = "tabShift";
@@ -178,6 +181,18 @@ namespace ShiftPlanner
             this.cmbMinHolidayCount.Size = new System.Drawing.Size(60, 20);
             this.cmbMinHolidayCount.TabIndex = 5;
             this.cmbMinHolidayCount.SelectedIndexChanged += new System.EventHandler(this.CmbMinHolidayCount_SelectedIndexChanged);
+            //
+            // btnAggregate
+            //
+            this.btnAggregate.Location = new System.Drawing.Point(426, 6);
+            this.btnAggregate.Name = "btnAggregate";
+            this.btnAggregate.Size = new System.Drawing.Size(75, 23);
+            this.btnAggregate.TabIndex = 6;
+            this.btnAggregate.Text = "集計";
+            this.btnAggregate.UseVisualStyleBackColor = true;
+            // Anchorを指定して常に左上に表示されるようにする
+            this.btnAggregate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
+            this.btnAggregate.Click += new System.EventHandler(this.Btn集計_Click);
             //
             // lblDefaultRequired
             //

--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -10,6 +10,7 @@ using System.Runtime.Serialization;
 using System.Windows.Forms.DataVisualization.Charting;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Text;
 
 namespace ShiftPlanner
 {
@@ -82,6 +83,12 @@ namespace ShiftPlanner
             LoadSettings();
 
             InitializeComponent(); // これだけでOK
+
+            // 集計ボタンを一番手前に表示
+            if (btnAggregate != null)
+            {
+                btnAggregate.BringToFront();
+            }
 
             // 初期表示月を当月に設定
             if (dtp対象月 != null)
@@ -1174,6 +1181,85 @@ namespace ShiftPlanner
             SetupShiftGrid();
             GenerateRandomShifts();
             UpdateAttendanceCounts();
+        }
+
+        /// <summary>
+        /// シフト表の必要人数を集計します。
+        /// </summary>
+        private void Btn集計_Click(object? sender, EventArgs e)
+        {
+            try
+            {
+                if (dtp対象月 == null || shiftTable == null)
+                {
+                    return;
+                }
+
+                if (enabledShiftTimes == null)
+                {
+                    MessageBox.Show("勤務時間の情報が取得できません。", "エラー");
+                    return;
+                }
+
+                var baseDate = new DateTime(dtp対象月.Value.Year, dtp対象月.Value.Month, 1);
+                int days = DateTime.DaysInMonth(baseDate.Year, baseDate.Month);
+
+                var dailyNeeds = new List<int>();
+
+                // 勤務時間行の開始・終了位置を取得
+                int startRow = members.Count + skillGroups.Count;
+                int endRow = Math.Min(startRow + enabledShiftTimes.Count, shiftTable.Rows.Count - 1);
+                // 想定行数より少ない場合はエラー
+                if (shiftTable.Rows.Count <= endRow)
+                {
+                    MessageBox.Show("シフト表データが不足しています。", "エラー");
+                    return;
+                }
+
+                for (int d = 0; d < days; d++)
+                {
+                    int col = dateColumnStartIndex + d;
+                    int sum = 0;
+                    for (int row = startRow; row < endRow; row++)
+                    {
+                        if (int.TryParse(shiftTable.Rows[row][col]?.ToString(), out int v))
+                        {
+                            sum += v;
+                        }
+                    }
+                    dailyNeeds.Add(sum);
+                }
+
+                int totalNeed = dailyNeeds.Sum();
+                int maxNeed = dailyNeeds.Count > 0 ? dailyNeeds.Max() : 0;
+
+                int workableDays = days - minHolidayCount;
+                if (workableDays <= 0)
+                {
+                    MessageBox.Show("最低休日日数が多すぎます。", "エラー");
+                    return;
+                }
+
+                int minMembersByTotal = (int)Math.Ceiling(totalNeed / (double)workableDays);
+                int requiredMembers = Math.Max(maxNeed, minMembersByTotal);
+
+                var sb = new StringBuilder();
+                sb.AppendLine("日別必要人数一覧");
+                for (int i = 0; i < dailyNeeds.Count; i++)
+                {
+                    sb.AppendLine($"{i + 1}日: {dailyNeeds[i]}人");
+                }
+                sb.AppendLine($"合計必要勤務日数: {totalNeed}");
+                sb.AppendLine($"最大日次必要人数: {maxNeed}");
+                sb.AppendLine($"1人当たり最大勤務可能日数: {workableDays}");
+                sb.AppendLine($"必要メンバー数: {requiredMembers}");
+
+                MessageBox.Show(sb.ToString(), "集計結果");
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"集計処理でエラーが発生しました: {ex.Message}");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## 概要
- 集計ボタンが表示されない問題を修正
- 集計ボタンを左上固定で表示し `BringToFront` で前面に配置
- 集計処理に追加の null チェックを実装

## テスト
- `dotnet build` (dotnet コマンドが存在しないため失敗)

------
https://chatgpt.com/codex/tasks/task_e_684d79c9b8688333b842f94ad749aeca