### PR TITLE
Fix saving of skill and shift time masters

### DIFF
--- a/ShiftPlanner/ShiftTimeMasterForm.cs
+++ b/ShiftPlanner/ShiftTimeMasterForm.cs
@@ -21,6 +21,9 @@ namespace ShiftPlanner
             SetupGrid();
             dtShiftTimes.CellFormatting += DtShiftTimes_CellFormatting;
             dtShiftTimes.CellClick += DtShiftTimes_CellClick;
+            // 編集確定とエラー表示を追加
+            dtShiftTimes.CurrentCellDirtyStateChanged += DtShiftTimes_CurrentCellDirtyStateChanged;
+            dtShiftTimes.DataError += DtShiftTimes_DataError;
         }
 
         /// <summary>
@@ -50,6 +53,8 @@ namespace ShiftPlanner
 
         private void BtnOk_Click(object? sender, EventArgs e)
         {
+            // 編集中のセルがあれば確定する
+            dtShiftTimes.EndEdit();
             DialogResult = DialogResult.OK;
         }
 
@@ -159,6 +164,27 @@ namespace ShiftPlanner
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// セル編集確定時に値をコミットします。
+        /// </summary>
+        private void DtShiftTimes_CurrentCellDirtyStateChanged(object? sender, EventArgs e)
+        {
+            if (dtShiftTimes.IsCurrentCellDirty)
+            {
+                dtShiftTimes.CommitEdit(DataGridViewDataErrorContexts.Commit);
+            }
+        }
+
+        /// <summary>
+        /// データエラー発生時に警告を表示します。
+        /// </summary>
+        private void DtShiftTimes_DataError(object? sender, DataGridViewDataErrorEventArgs e)
+        {
+            e.ThrowException = false;
+            string message = e.Exception?.Message ?? "入力値が正しくありません。";
+            MessageBox.Show($"データエラー: {message}", "エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
         }
     }
 }

--- a/ShiftPlanner/SkillGroupMasterForm.cs
+++ b/ShiftPlanner/SkillGroupMasterForm.cs
@@ -19,6 +19,10 @@ namespace ShiftPlanner
             InitializeComponent();
             dtSkillGroups.DataSource = _skillGroups;
             SetupGrid();
+            // 編集中の値が失われないように編集確定イベントを設定
+            dtSkillGroups.CurrentCellDirtyStateChanged += DtSkillGroups_CurrentCellDirtyStateChanged;
+            // 入力エラー時のメッセージ表示
+            dtSkillGroups.DataError += DtSkillGroups_DataError;
         }
 
         /// <summary>
@@ -42,6 +46,8 @@ namespace ShiftPlanner
 
         private void BtnOk_Click(object? sender, EventArgs e)
         {
+            // 編集中のセルがあれば確定する
+            dtSkillGroups.EndEdit();
             DialogResult = DialogResult.OK;
         }
 
@@ -74,6 +80,27 @@ namespace ShiftPlanner
             // 列幅をフォームのサイズに合わせて調整
             DataGridViewHelper.SetColumnsNotSortable(dtSkillGroups);
             DataGridViewHelper.FitColumnsToGrid(dtSkillGroups);
+        }
+
+        /// <summary>
+        /// セル編集確定時に値をコミットします。
+        /// </summary>
+        private void DtSkillGroups_CurrentCellDirtyStateChanged(object? sender, EventArgs e)
+        {
+            if (dtSkillGroups.IsCurrentCellDirty)
+            {
+                dtSkillGroups.CommitEdit(DataGridViewDataErrorContexts.Commit);
+            }
+        }
+
+        /// <summary>
+        /// データエラー発生時に警告を表示します。
+        /// </summary>
+        private void DtSkillGroups_DataError(object? sender, DataGridViewDataErrorEventArgs e)
+        {
+            e.ThrowException = false;
+            string message = e.Exception?.Message ?? "入力値が正しくありません。";
+            MessageBox.Show($"データエラー: {message}", "エラー", MessageBoxButtons.OK, MessageBoxIcon.Warning);
         }
     }
 }


### PR DESCRIPTION
## 概要
- スキルグループマスターと勤務時間マスターで、編集中の値が確実に保存されるよう修正しました
- DataGridView の編集確定処理とデータエラー処理を追加しています

## 変更内容
- 編集確定イベント `CurrentCellDirtyStateChanged` をハンドルし、`CommitEdit` を呼び出すように変更
- OK ボタン押下時に `EndEdit` を呼び出して未確定の編集を反映
- データエラー時には警告ダイアログを表示

## テスト
- `dotnet build` を実行しましたが、環境に `dotnet` コマンドが存在せずビルドできませんでした

------
https://chatgpt.com/codex/tasks/task_e_684d7e02bed48333b3cf81c8f813ceeb