### PR TITLE
Fix missing controls in MainForm

### DIFF
--- a/ShiftPlanner/MainForm.Designer.cs
+++ b/ShiftPlanner/MainForm.Designer.cs
@@ -41,6 +41,8 @@ namespace ShiftPlanner
         private TabPage tabShift;
         private DataGridView dtShifts;
         private Button btnShiftGenerate;
+        private ComboBox cmbDefaultRequired;
+        private Label lblDefaultRequired;
 
         /// <summary>
         /// 使用中のリソースをすべて解放します。
@@ -81,6 +83,8 @@ namespace ShiftPlanner
             this.tabShift = new System.Windows.Forms.TabPage();
             this.dtShifts = new System.Windows.Forms.DataGridView();
             this.btnShiftGenerate = new System.Windows.Forms.Button();
+            this.cmbDefaultRequired = new System.Windows.Forms.ComboBox();
+            this.lblDefaultRequired = new System.Windows.Forms.Label();
             this.tabControl1.SuspendLayout();
             this.tabShift.SuspendLayout();
             this.tabPage3.SuspendLayout();
@@ -134,6 +138,28 @@ namespace ShiftPlanner
             // 非表示部分はスクロールして閲覧できるようにする
             this.dtShifts.ScrollBars = System.Windows.Forms.ScrollBars.Both;
             this.dtShifts.TabIndex = 1;
+            //
+            // cmbDefaultRequired
+            //
+            this.cmbDefaultRequired.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbDefaultRequired.FormattingEnabled = true;
+            this.cmbDefaultRequired.Items.AddRange(new object[] {
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10"});
+            this.cmbDefaultRequired.Location = new System.Drawing.Point(200, 8);
+            this.cmbDefaultRequired.Name = "cmbDefaultRequired";
+            this.cmbDefaultRequired.Size = new System.Drawing.Size(60, 20);
+            this.cmbDefaultRequired.TabIndex = 3;
+            this.cmbDefaultRequired.SelectedIndexChanged += new System.EventHandler(this.CmbDefaultRequired_SelectedIndexChanged);
             //
             // cmbMinHolidayCount
             //

--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -1099,6 +1099,33 @@ namespace ShiftPlanner
             SaveSettings();
         }
 
+        /// <summary>
+        /// 必要人数のデフォルト値が変更されたときの処理
+        /// </summary>
+        private void CmbDefaultRequired_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (!int.TryParse(cmbDefaultRequired?.SelectedItem?.ToString(), out int v))
+            {
+                return;
+            }
+
+            if (shiftFrames == null)
+            {
+                return;
+            }
+
+            foreach (var frame in shiftFrames)
+            {
+                if (frame != null)
+                {
+                    frame.RequiredNumber = v;
+                }
+            }
+
+            SaveFrames();
+            SetupShiftGrid();
+        }
+
         private void UpdateRequestSummary()
         {
             if (dtRequestSummary == null)


### PR DESCRIPTION
## Summary
- MainForm.Designer.cs に `cmbDefaultRequired` と `lblDefaultRequired` を追加
- 必要人数デフォルト変更時の処理 `CmbDefaultRequired_SelectedIndexChanged` を実装

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build ShiftPlanner.sln` *(fails: reference assemblies for .NETFramework v4.8 not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7fa642488333b0e770f2689508bb