### PR TITLE
月更新時と終了時に編集内容を確実に保存

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -931,6 +931,20 @@ namespace ShiftPlanner
 
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
+            // 編集中のセルがある場合は確定する
+            if (dtShifts != null)
+            {
+                try
+                {
+                    dtShifts.EndEdit();
+                    dtShifts.CommitEdit(DataGridViewDataErrorContexts.Commit);
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show($"編集中のセル確定中にエラーが発生しました: {ex.Message}");
+                }
+            }
+
             SaveMembers();
             SaveRequests();
             SaveFrames();
@@ -1162,12 +1176,29 @@ namespace ShiftPlanner
         /// </summary>
         private void Btn月更新_Click(object? sender, EventArgs e)
         {
+            // 編集中の値を保存するためセルを確定
+            if (dtShifts != null)
+            {
+                try
+                {
+                    dtShifts.EndEdit();
+                    dtShifts.CommitEdit(DataGridViewDataErrorContexts.Commit);
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show($"セル確定中にエラーが発生しました: {ex.Message}");
+                }
+            }
+
             SetupShiftGrid();
             SetupRequestGrid();
             if (dtp対象月 != null && dtp分析月 != null)
             {
                 dtp分析月.Value = dtp対象月.Value;
             }
+
+            // シフト表を保存
+            SaveShiftTable();
         }
 
         /// <summary>


### PR DESCRIPTION
## 変更内容
- `OnFormClosing` でシフト表のセル編集を確定してから保存する処理を追加
- 月更新ボタン押下時にもセル編集を確定し、シフト表を保存するよう対応
- 例外発生時はメッセージボックスで通知するようエラーハンドリングを実装

## 動作確認
- `dotnet build` は環境に `dotnet` が存在せず実行できず

------
https://chatgpt.com/codex/tasks/task_e_684d83105ec48333b5f714c81ceba33b