### PR TITLE
不要となった必要人数デフォルト処理の削除

### DIFF
--- a/ShiftPlanner/MainForm.Designer.cs
+++ b/ShiftPlanner/MainForm.Designer.cs
@@ -41,8 +41,6 @@ namespace ShiftPlanner
         private TabPage tabShift;
         private DataGridView dtShifts;
         private Button btnShiftGenerate;
-        private ComboBox cmbDefaultRequired;
-        private Label lblDefaultRequired;
 
         /// <summary>
         /// 使用中のリソースをすべて解放します。
@@ -83,8 +81,6 @@ namespace ShiftPlanner
             this.tabShift = new System.Windows.Forms.TabPage();
             this.dtShifts = new System.Windows.Forms.DataGridView();
             this.btnShiftGenerate = new System.Windows.Forms.Button();
-            this.cmbDefaultRequired = new System.Windows.Forms.ComboBox();
-            this.lblDefaultRequired = new System.Windows.Forms.Label();
             this.tabControl1.SuspendLayout();
             this.tabShift.SuspendLayout();
             this.tabPage3.SuspendLayout();
@@ -113,8 +109,6 @@ namespace ShiftPlanner
             this.tabShift.Controls.Add(this.dtShifts);
             this.tabShift.Controls.Add(this.cmbMinHolidayCount);
             this.tabShift.Controls.Add(this.lblMinHolidayCount);
-            this.tabShift.Controls.Add(this.cmbDefaultRequired);
-            this.tabShift.Controls.Add(this.lblDefaultRequired);
             this.tabShift.Controls.Add(this.btnAggregate);
             this.tabShift.Controls.Add(this.btnShiftGenerate);
             this.tabShift.Location = new System.Drawing.Point(4, 22);
@@ -138,28 +132,6 @@ namespace ShiftPlanner
             // 非表示部分はスクロールして閲覧できるようにする
             this.dtShifts.ScrollBars = System.Windows.Forms.ScrollBars.Both;
             this.dtShifts.TabIndex = 1;
-            //
-            // cmbDefaultRequired
-            //
-            this.cmbDefaultRequired.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbDefaultRequired.FormattingEnabled = true;
-            this.cmbDefaultRequired.Items.AddRange(new object[] {
-            "0",
-            "1",
-            "2",
-            "3",
-            "4",
-            "5",
-            "6",
-            "7",
-            "8",
-            "9",
-            "10"});
-            this.cmbDefaultRequired.Location = new System.Drawing.Point(200, 8);
-            this.cmbDefaultRequired.Name = "cmbDefaultRequired";
-            this.cmbDefaultRequired.Size = new System.Drawing.Size(60, 20);
-            this.cmbDefaultRequired.TabIndex = 3;
-            this.cmbDefaultRequired.SelectedIndexChanged += new System.EventHandler(this.CmbDefaultRequired_SelectedIndexChanged);
             //
             // cmbMinHolidayCount
             //
@@ -194,15 +166,6 @@ namespace ShiftPlanner
             // Anchorを指定して常に左上に表示されるようにする
             this.btnAggregate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
             this.btnAggregate.Click += new System.EventHandler(this.Btn集計_Click);
-            //
-            // lblDefaultRequired
-            //
-            this.lblDefaultRequired.AutoSize = true;
-            this.lblDefaultRequired.Location = new System.Drawing.Point(110, 11);
-            this.lblDefaultRequired.Name = "lblDefaultRequired";
-            this.lblDefaultRequired.Size = new System.Drawing.Size(84, 12);
-            this.lblDefaultRequired.TabIndex = 2;
-            this.lblDefaultRequired.Text = "必要人数デフォルト";
             //
             // lblMinHolidayCount
             //

--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -601,29 +601,6 @@ namespace ShiftPlanner
         }
 
         /// <summary>
-        /// すべてのシフトフレームの必要人数をリセットします。
-        /// </summary>
-        private void ResetRequiredNumbers()
-        {
-            if (shiftFrames == null)
-            {
-                return; // null 安全対策
-            }
-
-            foreach (var frame in shiftFrames)
-            {
-                if (frame != null)
-                {
-                    frame.RequiredNumber = 0;
-                }
-            }
-
-            SaveFrames();
-        }
-
-
-
-        /// <summary>
         /// 割り当て結果を読み込みます。
         /// </summary>
         private void LoadAssignments()
@@ -1111,33 +1088,6 @@ namespace ShiftPlanner
             minHolidayCount = v;
             settings.MinHolidayCount = v;
             SaveSettings();
-        }
-
-        /// <summary>
-        /// 必要人数のデフォルト値が変更されたときの処理
-        /// </summary>
-        private void CmbDefaultRequired_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            if (!int.TryParse(cmbDefaultRequired?.SelectedItem?.ToString(), out int v))
-            {
-                return;
-            }
-
-            if (shiftFrames == null)
-            {
-                return;
-            }
-
-            foreach (var frame in shiftFrames)
-            {
-                if (frame != null)
-                {
-                    frame.RequiredNumber = v;
-                }
-            }
-
-            SaveFrames();
-            SetupShiftGrid();
         }
 
         private void UpdateRequestSummary()


### PR DESCRIPTION
## 概要
シフト表タブで使用していた「必要人数デフォルト」ドロップダウンと関連処理を削除しました。これに伴い、デザイナー・コード双方から該当コントロール定義やイベントを除去しています。

## 変更点
- `MainForm.Designer.cs` から `cmbDefaultRequired` と `lblDefaultRequired` のフィールド定義および初期化、タブへの追加処理を削除
- `MainForm.cs` から `CmbDefaultRequired_SelectedIndexChanged` と `ResetRequiredNumbers` を削除

## 動作確認
ビルド確認を試みましたが、環境に `dotnet` コマンドが存在しないため実行できませんでした。

------
https://chatgpt.com/codex/tasks/task_e_684f724fa5e883338f91998812844aaa