### PR TITLE
Excel import/export features

### DIFF
--- a/ShiftPlanner/ExcelHelper.cs
+++ b/ShiftPlanner/ExcelHelper.cs
@@ -1,0 +1,289 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization.Json;
+using System.Text;
+using System.Xml;
+
+namespace ShiftPlanner
+{
+    /// <summary>
+    /// Excel(XML)形式での入出力を補助するクラス
+    /// </summary>
+    public static class ExcelHelper
+    {
+        /// <summary>
+        /// シート名とデータリストを受け取りExcel XML形式で保存します。
+        /// </summary>
+        public static void エクスポート(Dictionary<string, IList> データ, string 保存先)
+        {
+            if (string.IsNullOrWhiteSpace(保存先) || データ == null)
+            {
+                return;
+            }
+
+            var settings = new XmlWriterSettings { Encoding = Encoding.UTF8, Indent = true };
+            using var writer = XmlWriter.Create(保存先, settings);
+            writer.WriteStartDocument();
+            writer.WriteStartElement("Workbook", "urn:schemas-microsoft-com:office:spreadsheet");
+            writer.WriteAttributeString("xmlns", "o", null, "urn:schemas-microsoft-com:office:office");
+            writer.WriteAttributeString("xmlns", "x", null, "urn:schemas-microsoft-com:office:excel");
+            writer.WriteAttributeString("xmlns", "ss", null, "urn:schemas-microsoft-com:office:spreadsheet");
+
+            foreach (var kv in データ)
+            {
+                string sheetName = kv.Key;
+                var list = kv.Value ?? new ArrayList();
+
+                writer.WriteStartElement("Worksheet");
+                writer.WriteAttributeString("ss", "Name", null, sheetName);
+                writer.WriteStartElement("Table");
+
+                var first = list.Count > 0 ? list[0] : null;
+                if (first != null)
+                {
+                    var props = first.GetType().GetProperties();
+                    // ヘッダ行
+                    writer.WriteStartElement("Row");
+                    foreach (var p in props)
+                    {
+                        writer.WriteStartElement("Cell");
+                        writer.WriteStartElement("Data");
+                        writer.WriteAttributeString("ss", "Type", null, "String");
+                        writer.WriteString(p.Name);
+                        writer.WriteEndElement(); // Data
+                        writer.WriteEndElement(); // Cell
+                    }
+                    writer.WriteEndElement(); // Row
+
+                    // データ行
+                    foreach (var item in list)
+                    {
+                        writer.WriteStartElement("Row");
+                        foreach (var p in props)
+                        {
+                            object? val = p.GetValue(item, null);
+                            string str = 値を文字列に変換(val);
+                            writer.WriteStartElement("Cell");
+                            writer.WriteStartElement("Data");
+                            writer.WriteAttributeString("ss", "Type", null, "String");
+                            writer.WriteString(str);
+                            writer.WriteEndElement();
+                            writer.WriteEndElement();
+                        }
+                        writer.WriteEndElement();
+                    }
+                }
+
+                writer.WriteEndElement(); // Table
+                writer.WriteEndElement(); // Worksheet
+            }
+
+            writer.WriteEndElement(); // Workbook
+            writer.WriteEndDocument();
+        }
+
+        /// <summary>
+        /// Excel XMLを読み込み、シートごとの行データを取得します。
+        /// </summary>
+        public static Dictionary<string, List<Dictionary<string, string>>> インポート(string ファイル)
+        {
+            var result = new Dictionary<string, List<Dictionary<string, string>>>();
+            if (string.IsNullOrWhiteSpace(ファイル) || !File.Exists(ファイル))
+            {
+                return result;
+            }
+
+            var doc = new XmlDocument();
+            doc.Load(ファイル);
+            var ns = new XmlNamespaceManager(doc.NameTable);
+            ns.AddNamespace("ss", "urn:schemas-microsoft-com:office:spreadsheet");
+
+            foreach (XmlNode sheet in doc.SelectNodes("//ss:Worksheet", ns) ?? new XmlNodeList[0])
+            {
+                var nameAttr = sheet.Attributes?["ss:Name"];
+                string sheetName = nameAttr?.Value ?? "Sheet";
+                var rows = new List<Dictionary<string, string>>();
+                var table = sheet.SelectSingleNode("ss:Table", ns);
+                if (table == null)
+                {
+                    continue;
+                }
+                var rowNodes = table.SelectNodes("ss:Row", ns);
+                if (rowNodes == null || rowNodes.Count == 0)
+                {
+                    result[sheetName] = rows;
+                    continue;
+                }
+
+                var headerCells = rowNodes[0].SelectNodes("ss:Cell/ss:Data", ns);
+                var headers = new List<string>();
+                if (headerCells != null)
+                {
+                    foreach (XmlNode cell in headerCells)
+                    {
+                        headers.Add(cell.InnerText);
+                    }
+                }
+
+                for (int i = 1; i < rowNodes.Count; i++)
+                {
+                    var row = rowNodes[i];
+                    var dataCells = row.SelectNodes("ss:Cell/ss:Data", ns);
+                    var dict = new Dictionary<string, string>();
+                    int col = 0;
+                    if (dataCells != null)
+                    {
+                        foreach (XmlNode cell in dataCells)
+                        {
+                            if (col < headers.Count)
+                            {
+                                dict[headers[col]] = cell.InnerText;
+                            }
+                            col++;
+                        }
+                    }
+                    rows.Add(dict);
+                }
+
+                result[sheetName] = rows;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// 行データからオブジェクトのリストへ変換します。
+        /// </summary>
+        public static List<T> 行データからオブジェクトへ変換<T>(List<Dictionary<string, string>> 行) where T : new()
+        {
+            var list = new List<T>();
+            if (行 == null)
+            {
+                return list;
+            }
+
+            var props = typeof(T).GetProperties();
+            foreach (var row in 行)
+            {
+                var obj = new T();
+                foreach (var p in props)
+                {
+                    if (row.TryGetValue(p.Name, out var s))
+                    {
+                        object? val = 文字列を値に変換(s, p.PropertyType);
+                        if (val != null)
+                        {
+                            p.SetValue(obj, val);
+                        }
+                    }
+                }
+                list.Add(obj);
+            }
+            return list;
+        }
+
+        private static string 値を文字列に変換(object? value)
+        {
+            if (value == null)
+            {
+                return string.Empty;
+            }
+
+            switch (value)
+            {
+                case DateTime dt:
+                    return dt.ToString("yyyy-MM-dd HH:mm:ss");
+                case TimeSpan ts:
+                    return ts.ToString();
+                case Enum e:
+                    return e.ToString();
+                case IList list when !(value is string):
+                    return JsonSerialize(value, value.GetType());
+                default:
+                    if (!value.GetType().IsPrimitive && !(value is string))
+                    {
+                        return JsonSerialize(value, value.GetType());
+                    }
+                    return Convert.ToString(value) ?? string.Empty;
+            }
+        }
+
+        private static object? 文字列を値に変換(string str, Type type)
+        {
+            if (type == typeof(string))
+            {
+                return str;
+            }
+            if (type == typeof(int))
+            {
+                int.TryParse(str, out int v);
+                return v;
+            }
+            if (type == typeof(double))
+            {
+                double.TryParse(str, out double d);
+                return d;
+            }
+            if (type == typeof(bool))
+            {
+                bool.TryParse(str, out bool b);
+                return b;
+            }
+            if (type == typeof(DateTime))
+            {
+                DateTime.TryParse(str, out DateTime dt);
+                return dt;
+            }
+            if (type == typeof(TimeSpan))
+            {
+                TimeSpan.TryParse(str, out TimeSpan ts);
+                return ts;
+            }
+            if (type.IsEnum)
+            {
+                try
+                {
+                    return Enum.Parse(type, str);
+                }
+                catch
+                {
+                    return Activator.CreateInstance(type);
+                }
+            }
+            if (typeof(IList).IsAssignableFrom(type) || (!type.IsPrimitive && type != typeof(string)))
+            {
+                if (string.IsNullOrWhiteSpace(str))
+                {
+                    return Activator.CreateInstance(type);
+                }
+                return JsonDeserialize(str, type);
+            }
+            return null;
+        }
+
+        private static string JsonSerialize(object value, Type type)
+        {
+            var serializer = new DataContractJsonSerializer(type);
+            using var ms = new MemoryStream();
+            serializer.WriteObject(ms, value);
+            return Encoding.UTF8.GetString(ms.ToArray());
+        }
+
+        private static object? JsonDeserialize(string json, Type type)
+        {
+            try
+            {
+                var serializer = new DataContractJsonSerializer(type);
+                using var ms = new MemoryStream(Encoding.UTF8.GetBytes(json));
+                return serializer.ReadObject(ms);
+            }
+            catch
+            {
+                return Activator.CreateInstance(type);
+            }
+        }
+    }
+}

--- a/ShiftPlanner/MainForm.Designer.cs
+++ b/ShiftPlanner/MainForm.Designer.cs
@@ -35,6 +35,8 @@ namespace ShiftPlanner
         private ToolStripMenuItem menuSkillGroupMaster;
         private ToolStripMenuItem menuShiftTimeMaster;
         private ToolStripMenuItem menuExportAnalysisCsv;
+        private ToolStripMenuItem menuExportExcel;
+        private ToolStripMenuItem menuImportExcel;
 
         private DateTimePicker dtp対象月;
         private Button btn月更新;
@@ -70,6 +72,8 @@ namespace ShiftPlanner
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.menuFile = new System.Windows.Forms.ToolStripMenuItem();
             this.menuExportAnalysisCsv = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuExportExcel = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuImportExcel = new System.Windows.Forms.ToolStripMenuItem();
             this.menuMaster = new System.Windows.Forms.ToolStripMenuItem();
             this.menuHolidayMaster = new System.Windows.Forms.ToolStripMenuItem();
             this.menuMemberMaster = new System.Windows.Forms.ToolStripMenuItem();
@@ -292,7 +296,9 @@ namespace ShiftPlanner
             // menuFile
             // 
             this.menuFile.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuExportAnalysisCsv});
+            this.menuExportAnalysisCsv,
+            this.menuExportExcel,
+            this.menuImportExcel});
             this.menuFile.Name = "menuFile";
             this.menuFile.Size = new System.Drawing.Size(53, 20);
             this.menuFile.Text = "ファイル";
@@ -303,9 +309,23 @@ namespace ShiftPlanner
             this.menuExportAnalysisCsv.Size = new System.Drawing.Size(142, 22);
             this.menuExportAnalysisCsv.Text = "分析CSV出力";
             this.menuExportAnalysisCsv.Click += new System.EventHandler(this.menuExportAnalysisCsv_Click);
-            // 
+            //
+            // menuExportExcel
+            //
+            this.menuExportExcel.Name = "menuExportExcel";
+            this.menuExportExcel.Size = new System.Drawing.Size(142, 22);
+            this.menuExportExcel.Text = "Excel出力";
+            this.menuExportExcel.Click += new System.EventHandler(this.menuExportExcel_Click);
+            //
+            // menuImportExcel
+            //
+            this.menuImportExcel.Name = "menuImportExcel";
+            this.menuImportExcel.Size = new System.Drawing.Size(142, 22);
+            this.menuImportExcel.Text = "Excel取込";
+            this.menuImportExcel.Click += new System.EventHandler(this.menuImportExcel_Click);
+            //
             // menuMaster
-            // 
+            //
             this.menuMaster.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menuHolidayMaster,
             this.menuMemberMaster,

--- a/ShiftPlanner/ShiftPlanner.csproj
+++ b/ShiftPlanner/ShiftPlanner.csproj
@@ -90,6 +90,7 @@
     <Compile Include="CustomHoliday.cs" />
     <!-- DataGridView の拡張メソッド -->
     <Compile Include="DataGridViewHelper.cs" />
+    <Compile Include="ExcelHelper.cs" />
     <Compile Include="AppSettings.cs" />
     <!-- メンバーごとの希望件数サマリ表示用クラス -->
     <Compile Include="RequestSummary.cs" />


### PR DESCRIPTION
## Summary
- add ExcelHelper for XML-based Excel export/import
- enable menu options in MainForm for Excel export and import
- wire up menu in MainForm.Designer
- include new helper in project file

## Testing
- `dotnet restore ShiftPlanner.sln` *(fails: command not found)*
- `dotnet build ShiftPlanner.sln -c Release` *(fails: command not found)*
- `dotnet test ShiftPlanner.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857851dfd348333acd1e976fab482d7