### PR TITLE
マスターメニューの順序変更

### DIFF
--- a/ShiftPlanner/MainForm.Designer.cs
+++ b/ShiftPlanner/MainForm.Designer.cs
@@ -326,11 +326,12 @@ namespace ShiftPlanner
             //
             // menuMaster
             //
+            // マスターの表示順を「祝日、スキル、勤務時間、メンバー」の順に変更
             this.menuMaster.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.menuHolidayMaster,
-            this.menuMemberMaster,
-            this.menuSkillGroupMaster,
-            this.menuShiftTimeMaster});
+            this.menuHolidayMaster,     // 祝日マスター
+            this.menuSkillGroupMaster,  // スキルグループマスター
+            this.menuShiftTimeMaster,   // 勤務時間マスター
+            this.menuMemberMaster});    // メンバーマスター
             this.menuMaster.Name = "menuMaster";
             this.menuMaster.Size = new System.Drawing.Size(54, 20);
             this.menuMaster.Text = "マスター";


### PR DESCRIPTION
## 概要
- メニューバーのマスター項目の並び順を `祝日 → スキル → 勤務時間 → メンバー` に修正しました。
- 表示順変更に合わせてコメントを追加し、各項目の役割を明記しました。

## 動作確認
- `dotnet build` を試行しましたが、環境に `dotnet` が存在しないためビルドは実行できませんでした。


------
https://chatgpt.com/codex/tasks/task_e_6870563c001883338e90275cbb0022cc