### PR TITLE
グリッド編集確定処理追加

### DIFF
--- a/ShiftPlanner/DataGridViewHelper.cs
+++ b/ShiftPlanner/DataGridViewHelper.cs
@@ -84,5 +84,38 @@ namespace ShiftPlanner
             column.AutoSizeMode = DataGridViewAutoSizeColumnMode.None;
             column.Width = width;
         }
+
+        /// <summary>
+        /// セル編集を確定させた上で DataGridView のフォーカスを外します。
+        /// </summary>
+        /// <param name="grid">対象の DataGridView</param>
+        /// <param name="nextFocus">フォーカスを移す先のコントロール。null の場合は親コントロールにフォーカスします。</param>
+        public static void セル確定してフォーカス解除(DataGridView? grid, Control? nextFocus)
+        {
+            if (grid == null)
+            {
+                return;
+            }
+
+            try
+            {
+                grid.EndEdit();
+                grid.CommitEdit(DataGridViewDataErrorContexts.Commit);
+
+                if (nextFocus != null)
+                {
+                    nextFocus.Focus();
+                }
+                else if (grid.Parent != null)
+                {
+                    grid.Parent.Focus();
+                }
+            }
+            catch (Exception ex)
+            {
+                // フォーカス解除処理中の例外は致命的でないためログに出力のみ行う
+                Console.WriteLine($"セル確定中にエラーが発生しました: {ex.Message}");
+            }
+        }
     }
 }

--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -1247,19 +1247,8 @@ namespace ShiftPlanner
         /// </summary>
         private void Btn月更新_Click(object? sender, EventArgs e)
         {
-            // 編集中の値を保存するためセルを確定
-            if (dtShifts != null)
-            {
-                try
-                {
-                    dtShifts.EndEdit();
-                    dtShifts.CommitEdit(DataGridViewDataErrorContexts.Commit);
-                }
-                catch (Exception ex)
-                {
-                    MessageBox.Show($"セル確定中にエラーが発生しました: {ex.Message}");
-                }
-            }
+            // 編集中の値を確定し、グリッドのフォーカスを外す
+            DataGridViewHelper.セル確定してフォーカス解除(dtShifts, btn月更新);
 
             SetupShiftGrid();
             SetupRequestGrid();
@@ -1277,6 +1266,9 @@ namespace ShiftPlanner
         /// </summary>
         private void BtnShiftGenerate_Click(object? sender, EventArgs e)
         {
+            // ボタン押下時に編集中のセルを確定し、フォーカスを外す
+            DataGridViewHelper.セル確定してフォーカス解除(dtShifts, btnShiftGenerate);
+
             // メンバー数が変更されている可能性があるため
             // 事前にグリッドを再構築して反映させる
             SetupShiftGrid();


### PR DESCRIPTION
## 概要
- DataGridViewHelper にセル確定とフォーカス解除を行う `セル確定してフォーカス解除` メソッドを追加
- 月更新ボタンとシフト更新ボタンのクリック時に上記メソッドを利用し、編集中のセルを確実に確定させるよう修正

## テスト
- `dotnet build ShiftPlanner.sln` (コマンド失敗: `dotnet: command not found`)


------
https://chatgpt.com/codex/tasks/task_e_68705810d6bc8333a39fb246d3196d5c