### PR TITLE
個別日程調整タブの追加と希望登録機能の拡張

### DIFF
--- a/ShiftPlanner/MainForm.Designer.cs
+++ b/ShiftPlanner/MainForm.Designer.cs
@@ -203,7 +203,7 @@ namespace ShiftPlanner
             this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
             this.tabPage3.Size = new System.Drawing.Size(1385, 808);
             this.tabPage3.TabIndex = 2;
-            this.tabPage3.Text = "希望";
+            this.tabPage3.Text = "個別日程調整";
             this.tabPage3.UseVisualStyleBackColor = true;
             // 
             // dtRequestSummary

--- a/ShiftPlanner/RequestSummary.cs
+++ b/ShiftPlanner/RequestSummary.cs
@@ -9,6 +9,8 @@ namespace ShiftPlanner
     {
         public string メンバー { get; set; } = string.Empty;
         public int 出勤希望数 { get; set; }
-        public int 休希望数 { get; set; }
+        public int 希望休数 { get; set; }
+        public int 有休数 { get; set; }
+        public int 健康診断数 { get; set; }
     }
 }

--- a/ShiftPlanner/RequestType.cs
+++ b/ShiftPlanner/RequestType.cs
@@ -1,0 +1,20 @@
+using System.Runtime.Serialization;
+
+namespace ShiftPlanner
+{
+    /// <summary>
+    /// 個別日程調整の種別を表す列挙。
+    /// </summary>
+    [DataContract]
+    public enum 申請種別
+    {
+        [EnumMember]
+        勤務希望 = 0,
+        [EnumMember]
+        希望休 = 1,
+        [EnumMember]
+        有休 = 2,
+        [EnumMember]
+        健康診断 = 3
+    }
+}

--- a/ShiftPlanner/ShiftGenerator.cs
+++ b/ShiftPlanner/ShiftGenerator.cs
@@ -36,11 +36,11 @@ namespace ShiftPlanner
                     (frame.Date.DayOfWeek != DayOfWeek.Sunday || m.WorksOnSunday))
                     .ToList();
 
-                // 休み希望があれば割当対象から除外
+                // 休み希望(勤務希望以外)があれば割当対象から除外
                 if (requests != null)
                 {
                     eligible = eligible
-                        .Where(m => !requests.Any(r => r.MemberId == m.Id && r.Date.Date == frame.Date.Date && r.IsHolidayRequest))
+                        .Where(m => !requests.Any(r => r.MemberId == m.Id && r.Date.Date == frame.Date.Date && r.種別 != 申請種別.勤務希望))
                         .ToList();
                 }
 
@@ -55,7 +55,7 @@ namespace ShiftPlanner
                 if (requests != null)
                 {
                     priorityMembers = eligible
-                        .Where(m => requests.Any(r => r.MemberId == m.Id && r.Date.Date == frame.Date.Date && !r.IsHolidayRequest))
+                        .Where(m => requests.Any(r => r.MemberId == m.Id && r.Date.Date == frame.Date.Date && r.種別 == 申請種別.勤務希望))
                         .ToList();
                 }
 

--- a/ShiftPlanner/ShiftGeneratorGreedy.cs
+++ b/ShiftPlanner/ShiftGeneratorGreedy.cs
@@ -125,7 +125,7 @@ namespace ShiftPlanner
 
             // メンバーごとの現在休日数をカウント
             var holidayCounts = members.ToDictionary(m => m.Id, m =>
-                requests.Count(r => r.MemberId == m.Id && r.IsHolidayRequest && r.Date.Year == baseDate.Year && r.Date.Month == baseDate.Month));
+                requests.Count(r => r.MemberId == m.Id && r.種別 != 申請種別.勤務希望 && r.Date.Year == baseDate.Year && r.Date.Month == baseDate.Month));
 
             // 最低休日日数を満たすための追加休み候補を生成
             var extraHolidays = new Dictionary<int, HashSet<int>>();
@@ -176,9 +176,10 @@ namespace ShiftPlanner
                 foreach (var m in members)
                 {
                     var req = requests.FirstOrDefault(r => r.MemberId == m.Id && r.Date.Date == date.Date);
-                    if (req != null && req.IsHolidayRequest)
+                    if (req != null && req.種別 != 申請種別.勤務希望)
                     {
-                        result[m.Id][date] = "希休";
+                        string name = req.種別 == 申請種別.希望休 ? "希休" : req.種別 == 申請種別.有休 ? "有休" : "健診";
+                        result[m.Id][date] = name;
                         states[m.Id].WorkStreak = 0;
                         if (dailyHolidayCapacity.ContainsKey(d))
                         {
@@ -289,7 +290,7 @@ namespace ShiftPlanner
                 {
                     if (dayAssignments.TryGetValue(m.Id, out var shiftName))
                     {
-                        bool preferWork = requests.Any(r => r.MemberId == m.Id && r.Date.Date == date.Date && !r.IsHolidayRequest);
+                        bool preferWork = requests.Any(r => r.MemberId == m.Id && r.Date.Date == date.Date && r.種別 == 申請種別.勤務希望);
                         result[m.Id][date] = preferWork ? $"希{shiftName}" : shiftName;
                     }
                     else if (string.IsNullOrEmpty(result[m.Id][date]))

--- a/ShiftPlanner/ShiftRequest.cs
+++ b/ShiftPlanner/ShiftRequest.cs
@@ -18,8 +18,8 @@ namespace ShiftPlanner
         [DataMember]
         public DateTime Date { get; set; }
 
-        /// <summary>true の場合は休み希望、false の場合は勤務希望</summary>
+        /// <summary>個別日程調整の種別</summary>
         [DataMember]
-        public bool IsHolidayRequest { get; set; }
+        public 申請種別 種別 { get; set; } = 申請種別.勤務希望;
     }
 }

--- a/ShiftPlanner/ShiftRequestForm.Designer.cs
+++ b/ShiftPlanner/ShiftRequestForm.Designer.cs
@@ -13,7 +13,7 @@ namespace ShiftPlanner
         // --- UI コントロール定義 ---
         private ComboBox cmbMember;
         private DateTimePicker dtpDate;
-        private CheckBox chkHoliday;
+        private ComboBox cmb種別;
         private Button btnOk;
         private Button btnCancel;
 
@@ -36,7 +36,7 @@ namespace ShiftPlanner
         {
             this.cmbMember = new ComboBox();
             this.dtpDate = new DateTimePicker();
-            this.chkHoliday = new CheckBox();
+            this.cmb種別 = new ComboBox();
             this.btnOk = new Button();
             this.btnCancel = new Button();
 
@@ -51,9 +51,10 @@ namespace ShiftPlanner
             this.dtpDate.Location = new System.Drawing.Point(12, 41);
             this.dtpDate.Size = new System.Drawing.Size(200, 23);
 
-            // chkHoliday
-            this.chkHoliday.Location = new System.Drawing.Point(12, 70);
-            this.chkHoliday.Text = "休み希望";
+            // cmb種別
+            this.cmb種別.DropDownStyle = ComboBoxStyle.DropDownList;
+            this.cmb種別.Location = new System.Drawing.Point(12, 70);
+            this.cmb種別.Size = new System.Drawing.Size(200, 23);
 
             // btnOk
             this.btnOk.Location = new System.Drawing.Point(12, 100);
@@ -71,7 +72,7 @@ namespace ShiftPlanner
             this.ClientSize = new System.Drawing.Size(224, 135);
             this.Controls.Add(this.cmbMember);
             this.Controls.Add(this.dtpDate);
-            this.Controls.Add(this.chkHoliday);
+            this.Controls.Add(this.cmb種別);
             this.Controls.Add(this.btnOk);
             this.Controls.Add(this.btnCancel);
             this.FormBorderStyle = FormBorderStyle.FixedDialog;

--- a/ShiftPlanner/ShiftRequestForm.cs
+++ b/ShiftPlanner/ShiftRequestForm.cs
@@ -20,8 +20,8 @@ namespace ShiftPlanner
         /// コンストラクタ
         /// </summary>
         /// <param name="members">メンバー一覧</param>
-        /// <param name="holidayChecked">休み希望チェックの初期値</param>
-        public ShiftRequestForm(List<Member> members, bool holidayChecked = false)
+        /// <param name="初期種別">初期表示する種別</param>
+        public ShiftRequestForm(List<Member> members, 申請種別 初期種別 = 申請種別.希望休)
         {
             this.members = members ?? new List<Member>();
             InitializeComponent();
@@ -39,8 +39,9 @@ namespace ShiftPlanner
                 MessageBox.Show($"メンバー情報の読込に失敗しました: {ex.Message}");
             }
 
-            // 休み希望チェックボックスの初期状態を設定
-            chkHoliday.Checked = holidayChecked;
+            // 種別コンボボックスの初期値を設定
+            cmb種別.DataSource = Enum.GetValues(typeof(申請種別));
+            cmb種別.SelectedItem = 初期種別;
         }
 
         // このメソッドの内容は ShiftRequestForm.Designer.cs に移動しました。
@@ -54,11 +55,17 @@ namespace ShiftPlanner
                 return;
             }
 
+            if (cmb種別.SelectedItem == null)
+            {
+                MessageBox.Show("種別を選択してください。");
+                return;
+            }
+
             this.ShiftRequest = new ShiftRequest
             {
                 MemberId = member.Id,
                 Date = dtpDate.Value.Date,
-                IsHolidayRequest = chkHoliday.Checked
+                種別 = (申請種別)cmb種別.SelectedItem
             };
             this.DialogResult = DialogResult.OK;
         }


### PR DESCRIPTION
## 変更内容
- 希望タブを「個別日程調整」タブへ名称変更
- 申請種別 `申請種別` を追加し、勤務希望・希望休・有休・健康診断を登録可能に
- ShiftRequest クラスを修正し種別を保持
- 各フォームとグリッドを申請種別に対応
- Excel 出力・取込のシート名を更新
- RequestSummary を拡張し各種別の件数を表示
- シフト生成ロジックを申請種別に合わせて更新

## テスト
- `dotnet build` を試みましたが、環境に `dotnet` コマンドが存在せずビルドできませんでした。


------
https://chatgpt.com/codex/tasks/task_e_6870cbdb656c8333bcf2f845e002c709