### PR TITLE
申請種別列挙体をプロジェクトに追加

### DIFF
--- a/ShiftPlanner/ShiftPlanner.csproj
+++ b/ShiftPlanner/ShiftPlanner.csproj
@@ -96,6 +96,8 @@
     <Compile Include="AppSettings.cs" />
     <!-- メンバーごとの希望件数サマリ表示用クラス -->
     <Compile Include="RequestSummary.cs" />
+    <!-- 個別日程調整の種別を定義する列挙体 -->
+    <Compile Include="RequestType.cs" />
     <Compile Include="HolidayMasterForm.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
## 概要
`ShiftRequest.cs` や `ShiftRequestForm.cs` では `申請種別` 列挙体を使用していましたが、
`ShiftPlanner.csproj` に `RequestType.cs` が含まれておらずビルドエラーとなっていました。

## 変更内容
- `ShiftPlanner.csproj` に `RequestType.cs` をコンパイル対象として追加
  - コメントを付与し、役割を明確化しました

## テスト
- `dotnet` コマンドが存在しないためビルドは未実施
  - 必要な場合は .NET 環境を用意してビルドしてください


------
https://chatgpt.com/codex/tasks/task_e_68732d62d3c88333bee603cc05a7bfbe