### PR TITLE
Consoleエラー修正

### DIFF
--- a/ShiftPlanner/DataGridViewHelper.cs
+++ b/ShiftPlanner/DataGridViewHelper.cs
@@ -1,3 +1,4 @@
+using System; // 例外およびコンソール利用のため
 using System.Windows.Forms;
 
 namespace ShiftPlanner


### PR DESCRIPTION
## 概要
`DataGridViewHelper.cs` で `Console` と `Exception` が認識されないエラーが発生していたため、`System` 名前空間を追加しました。

## 変更点
- `DataGridViewHelper.cs` の先頭に `using System;` を追加し、コメントを付与しました。

## 動作確認
- `dotnet` コマンドが利用できない環境のためビルドは行えていませんが、コード上の参照エラーは解消されています。

------
https://chatgpt.com/codex/tasks/task_e_687332e78ae08333ab0ce0ac8d2d8d8f