### PR TITLE
セルフォーマット時の範囲外アクセスを防止

### DIFF
--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -1486,6 +1486,12 @@ namespace ShiftPlanner
                 return;
             }
 
+            // データテーブルの範囲外アクセスを防止
+            if (e.RowIndex >= shiftTable.Rows.Count || e.ColumnIndex >= shiftTable.Columns.Count)
+            {
+                return;
+            }
+
             // 休み数列の色付け判定
             int restColumnIndex = 1 + enabledShiftTimes.Count;
             if (e.ColumnIndex == restColumnIndex && e.RowIndex < members.Count)


### PR DESCRIPTION
## 概要
- Shift 表を再生成した際に `IndexOutOfRangeException` が発生する問題を修正しました。
- `DtShifts_CellFormatting` 内で DataTable の行・列数を超えるインデックスが渡された場合に処理を中止するガードを追加しました。

## テスト
- `dotnet build` を試行しましたが、環境に `dotnet` が存在せずビルドを実行できませんでした。

------
https://chatgpt.com/codex/tasks/task_e_68733f503aa083339d3437d51ee56081