### PR TITLE
シフト表に勤怠時間選択と一括修正機能を追加

### DIFF
--- a/ShiftPlanner/MainForm.Designer.cs
+++ b/ShiftPlanner/MainForm.Designer.cs
@@ -43,6 +43,8 @@ namespace ShiftPlanner
         private TabPage tabShift;
         private DataGridView dtShifts;
         private Button btnShiftGenerate;
+        private ComboBox cmb勤怠時間;
+        private Button btnセル修正;
 
         /// <summary>
         /// 使用中のリソースをすべて解放します。
@@ -85,6 +87,8 @@ namespace ShiftPlanner
             this.tabShift = new System.Windows.Forms.TabPage();
             this.dtShifts = new System.Windows.Forms.DataGridView();
             this.btnShiftGenerate = new System.Windows.Forms.Button();
+            this.cmb勤怠時間 = new System.Windows.Forms.ComboBox();
+            this.btnセル修正 = new System.Windows.Forms.Button();
             this.tabControl1.SuspendLayout();
             this.tabShift.SuspendLayout();
             this.tabPage3.SuspendLayout();
@@ -114,6 +118,8 @@ namespace ShiftPlanner
             this.tabShift.Controls.Add(this.cmbMinHolidayCount);
             this.tabShift.Controls.Add(this.lblMinHolidayCount);
             this.tabShift.Controls.Add(this.btnAggregate);
+            this.tabShift.Controls.Add(this.cmb勤怠時間);
+            this.tabShift.Controls.Add(this.btnセル修正);
             this.tabShift.Controls.Add(this.btnShiftGenerate);
             this.tabShift.Location = new System.Drawing.Point(4, 22);
             this.tabShift.Name = "tabShift";
@@ -170,6 +176,25 @@ namespace ShiftPlanner
             // Anchorを指定して常に左上に表示されるようにする
             this.btnAggregate.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)));
             this.btnAggregate.Click += new System.EventHandler(this.Btn集計_Click);
+
+            // cmb勤怠時間
+            //
+            this.cmb勤怠時間.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmb勤怠時間.FormattingEnabled = true;
+            this.cmb勤怠時間.Location = new System.Drawing.Point(507, 8);
+            this.cmb勤怠時間.Name = "cmb勤怠時間";
+            this.cmb勤怠時間.Size = new System.Drawing.Size(121, 20);
+            this.cmb勤怠時間.TabIndex = 7;
+
+            // btnセル修正
+            //
+            this.btnセル修正.Location = new System.Drawing.Point(634, 6);
+            this.btnセル修正.Name = "btnセル修正";
+            this.btnセル修正.Size = new System.Drawing.Size(75, 23);
+            this.btnセル修正.TabIndex = 8;
+            this.btnセル修正.Text = "修正";
+            this.btnセル修正.UseVisualStyleBackColor = true;
+            this.btnセル修正.Click += new System.EventHandler(this.Btnセル修正_Click);
             //
             // lblMinHolidayCount
             //

--- a/ShiftPlanner/MainForm.cs
+++ b/ShiftPlanner/MainForm.cs
@@ -1283,6 +1283,48 @@ namespace ShiftPlanner
         }
 
         /// <summary>
+        /// 選択中のセルにコンボボックスの値を設定します。
+        /// </summary>
+        private void Btnセル修正_Click(object? sender, EventArgs e)
+        {
+            if (dtShifts == null || cmb勤怠時間 == null)
+            {
+                return;
+            }
+
+            DataGridViewHelper.セル確定してフォーカス解除(dtShifts, btnセル修正);
+
+            string value = cmb勤怠時間.SelectedItem?.ToString() ?? string.Empty;
+            if (string.IsNullOrEmpty(value))
+            {
+                return;
+            }
+
+            foreach (DataGridViewCell cell in dtShifts.SelectedCells)
+            {
+                if (cell.RowIndex < 0 || cell.ColumnIndex < dateColumnStartIndex)
+                {
+                    continue;
+                }
+
+                if (cell.RowIndex >= members.Count)
+                {
+                    continue;
+                }
+
+                if (cell.ReadOnly)
+                {
+                    continue;
+                }
+
+                cell.Value = value;
+            }
+
+            UpdateAttendanceCounts();
+            SaveShiftTableAsync();
+        }
+
+        /// <summary>
         /// 日付列ヘッダーの文字色を曜日・祝日に応じて設定します。
         /// </summary>
         /// <param name="baseDate">対象月の初日</param>
@@ -1414,6 +1456,21 @@ namespace ShiftPlanner
             if (dtShifts == null || dtp対象月 == null)
             {
                 return;
+            }
+
+            // 勤怠時間選択用コンボボックスを更新
+            if (cmb勤怠時間 != null)
+            {
+                cmb勤怠時間.Items.Clear();
+                foreach (var st in shiftTimes.Where(s => s != null && s.IsEnabled))
+                {
+                    cmb勤怠時間.Items.Add(st.Name);
+                }
+                cmb勤怠時間.Items.Add("休");
+                if (cmb勤怠時間.Items.Count > 0 && cmb勤怠時間.SelectedIndex < 0)
+                {
+                    cmb勤怠時間.SelectedIndex = 0;
+                }
             }
 
             // 有効な勤務時間を抽出して保持


### PR DESCRIPTION
## 概要
- シフト表タブに勤怠時間マスターを選択するドロップダウンと修正ボタンを追加
- 修正ボタン押下で選択セルの値をドロップダウンの値に置き換え
- 勤怠時間マスター変更時やシフト表再生成時にドロップダウンを更新
- 処理時は出勤人数等の集計更新とシフト表の保存を実施

## テスト
- `dotnet build` を試行したが `dotnet` コマンドが存在せずビルドできず
- `apt-get update` もネットワーク制限により失敗したため依存関係の導入不可


------
https://chatgpt.com/codex/tasks/task_e_68747ac1aa148333b6a26884ee062c29