### PR TITLE
ログ出力の不具合修正

### DIFF
--- a/ShiftPlanner/ShiftGeneratorGreedy.cs
+++ b/ShiftPlanner/ShiftGeneratorGreedy.cs
@@ -231,7 +231,10 @@ namespace ShiftPlanner
                     .OrderBy(x => x.Count)
                     .Select(x => x.Group)
                     .ToList();
-                Console.WriteLine($"[Generate] {date:yyyy-MM-dd} スキルグループ優先順: {string.Join(',', skillGroupOrder.Select(s => s.Name))}");
+                // スキルグループの割り当て順をログに出力
+                Console.WriteLine(
+                    $"[Generate] {date:yyyy-MM-dd} スキルグループ優先順: " +
+                    string.Join(",", skillGroupOrder.Select(s => s.Name)));
 
                 // Phase-B: スキルグループ要件の充足
                 foreach (var sg in skillGroupOrder)
@@ -278,7 +281,10 @@ namespace ShiftPlanner
                     .OrderBy(x => x.Count)
                     .Select(x => x.Time)
                     .ToList();
-                Console.WriteLine($"[Generate] {date:yyyy-MM-dd} 勤務時間優先順: {string.Join(',', shiftTimeOrder.Select(t => t.Name))}");
+                // 勤務時間帯の割り当て順をログに出力
+                Console.WriteLine(
+                    $"[Generate] {date:yyyy-MM-dd} 勤務時間優先順: " +
+                    string.Join(",", shiftTimeOrder.Select(t => t.Name)));
 
                 // Phase-C: 残りの勤務枠を割り当て
                 foreach (var st in shiftTimeOrder)


### PR DESCRIPTION
## 変更内容
- スキルグループおよび勤務時間帯表示の `Console.WriteLine` で `string.Join` の区切り文字指定が誤っておりビルドエラーになっていたため修正
- `string.Join` の引数を `","` で明示し、`IEnumerable<string>` をそのまま渡す形式に変更
- ログ出力の前にコメントを追記し処理内容を明確化

## 確認結果
- `dotnet build` を試行しましたが環境に .NET SDK が存在しないため実行できませんでした


------
https://chatgpt.com/codex/tasks/task_e_6874bac9ca4483339eea43cc421c2209