### PR TITLE
不要なSlot構造体の削除

### DIFF
--- a/ShiftPlanner/ShiftGeneratorGreedy.cs
+++ b/ShiftPlanner/ShiftGeneratorGreedy.cs
@@ -27,17 +27,6 @@ namespace ShiftPlanner
         }
 
         /// <summary>
-        /// 勤務枠情報を表す構造体。
-        /// 必要に応じて SkillGroup 名を保持します。
-        /// </summary>
-        private struct Slot
-        {
-            public DateTime Date { get; set; }
-            public string ShiftName { get; set; }
-            public string? RequiredSkill { get; set; }
-        }
-
-        /// <summary>
         /// 指定した条件からシフト表を生成します。
         /// </summary>
         /// <param name="members">メンバー一覧</param>


### PR DESCRIPTION
## 概要
`ShiftGeneratorGreedy.cs` 内で未使用となっていた内部構造体 `Slot` を削除しました。これによりコードの保守性を向上させています。

## 変更点
- `ShiftGeneratorGreedy.cs` から `Slot` 構造体の定義を削除

## テスト
- `dotnet --version` 実行 → `command not found`
- `dotnet build ShiftPlanner.sln -c Release` 実行 → `command not found`
環境に `dotnet` が存在しなかったためビルドは行えませんでした。

------
https://chatgpt.com/codex/tasks/task_e_687ce5dafbf48333acb7fcf8634dde9d