### PR TITLE
新規テストプロジェクト追加とワークフロー更新

### DIFF
--- a/.github/workflows/net48-build._yml
+++ b/.github/workflows/net48-build._yml
@@ -23,3 +23,6 @@ jobs:
 
     - name: ビルドを実行
       run: msbuild ShiftPlanner.sln /p:Configuration=Release
+
+    - name: テストを実行
+      run: dotnet test ShiftPlanner.sln --no-build --configuration Release

--- a/ShiftPlanner.Tests/ShiftPlanner.Tests.csproj
+++ b/ShiftPlanner.Tests/ShiftPlanner.Tests.csproj
@@ -3,10 +3,12 @@
     <TargetFramework>net48</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ShiftPlanner\ShiftPlanner.csproj" />

--- a/ShiftPlanner.Tests/Tests/ShiftAnalyzerTests.cs
+++ b/ShiftPlanner.Tests/Tests/ShiftAnalyzerTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace ShiftPlanner.Tests
+{
+    /// <summary>
+    /// ShiftAnalyzer の主要メソッドをテストします。
+    /// 仕様書の「月別の労働時間集計」「シフトタイプ分布の取得」に対応。
+    /// </summary>
+    public class ShiftAnalyzerTests
+    {
+        [Fact]
+        public void CalculateMonthlyHours_ReturnsSumOfHoursForSpecifiedMonth()
+        {
+            var shifts = new List<ShiftPlanner.ShiftFrame>
+            {
+                new ShiftPlanner.ShiftFrame
+                {
+                    Date = new DateTime(2024, 5, 1),
+                    ShiftStart = TimeSpan.FromHours(9),
+                    ShiftEnd = TimeSpan.FromHours(17)
+                },
+                new ShiftPlanner.ShiftFrame
+                {
+                    Date = new DateTime(2024, 5, 2),
+                    ShiftStart = TimeSpan.FromHours(8),
+                    ShiftEnd = TimeSpan.FromHours(16)
+                },
+                // 別月のシフトは集計対象外
+                new ShiftPlanner.ShiftFrame
+                {
+                    Date = new DateTime(2024, 4, 30),
+                    ShiftStart = TimeSpan.FromHours(9),
+                    ShiftEnd = TimeSpan.FromHours(17)
+                }
+            };
+
+            var result = ShiftPlanner.ShiftAnalyzer.CalculateMonthlyHours(shifts, 2024, 5);
+
+            result.Should().Be(TimeSpan.FromHours(16));
+        }
+
+        [Fact]
+        public void GetShiftTypeDistribution_ReturnsCountsByType()
+        {
+            var shifts = new List<ShiftPlanner.ShiftFrame>
+            {
+                new ShiftPlanner.ShiftFrame { Date = new DateTime(2024, 5, 1), ShiftType = "Day" },
+                new ShiftPlanner.ShiftFrame { Date = new DateTime(2024, 5, 2), ShiftType = "Day" },
+                new ShiftPlanner.ShiftFrame { Date = new DateTime(2024, 5, 3), ShiftType = "Night" },
+                // 別月は含めない
+                new ShiftPlanner.ShiftFrame { Date = new DateTime(2024, 4, 30), ShiftType = "Night" }
+            };
+
+            var result = ShiftPlanner.ShiftAnalyzer.GetShiftTypeDistribution(shifts, 2024, 5);
+
+            result.Should().ContainKey("Day").WhichValue.Should().Be(2);
+            result.Should().ContainKey("Night").WhichValue.Should().Be(1);
+            result.Should().NotContainKey("");
+        }
+    }
+}

--- a/ShiftPlanner.Tests/Tests/ShuffleTests.cs
+++ b/ShiftPlanner.Tests/Tests/ShuffleTests.cs
@@ -1,19 +1,19 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
+using FluentAssertions;
 using System.Collections.Generic;
 using ShiftPlanner;
 
 namespace ShiftPlanner.Tests
 {
-    [TestClass]
     public class ShuffleTests
     {
-        [TestMethod]
+        [Fact]
         public void Shuffle_DoesNotChangeElementCount()
         {
             var list = new List<int> { 1, 2, 3, 4, 5 };
             var original = list.Count;
             ShiftGenerator.Shuffle(list);
-            Assert.AreEqual(original, list.Count);
+            list.Count.Should().Be(original);
         }
     }
 }

--- a/ShiftPlanner/ShiftAnalyzer.cs
+++ b/ShiftPlanner/ShiftAnalyzer.cs
@@ -16,9 +16,23 @@ namespace ShiftPlanner
         /// </summary>
         public static TimeSpan CalculateMonthlyHours(IEnumerable<ShiftFrame> shifts, int year, int month)
         {
-            return shifts
-                .Where(s => s.Date.Year == year && s.Date.Month == month)
-                .Aggregate(TimeSpan.Zero, (acc, s) => acc + (s.ShiftEnd - s.ShiftStart));
+            if (shifts == null)
+            {
+                SimpleLogger.Error("[CalculateMonthlyHours] shifts is null");
+                return TimeSpan.Zero;
+            }
+
+            try
+            {
+                return shifts
+                    .Where(s => s.Date.Year == year && s.Date.Month == month)
+                    .Aggregate(TimeSpan.Zero, (acc, s) => acc + (s.ShiftEnd - s.ShiftStart));
+            }
+            catch (Exception ex)
+            {
+                SimpleLogger.Error("[CalculateMonthlyHours] 集計に失敗しました", ex);
+                return TimeSpan.Zero;
+            }
         }
 
 
@@ -36,10 +50,18 @@ namespace ShiftPlanner
                 return new Dictionary<string, int>();
             }
 
-            return shifts
-                .Where(s => s.Date.Year == year && s.Date.Month == month)
-                .GroupBy(s => s.ShiftType ?? string.Empty)
-                .ToDictionary(g => g.Key, g => g.Count());
+            try
+            {
+                return shifts
+                    .Where(s => s.Date.Year == year && s.Date.Month == month)
+                    .GroupBy(s => s.ShiftType ?? string.Empty)
+                    .ToDictionary(g => g.Key, g => g.Count());
+            }
+            catch (Exception ex)
+            {
+                SimpleLogger.Error("[GetShiftTypeDistribution] 集計に失敗しました", ex);
+                return new Dictionary<string, int>();
+            }
         }
 
 


### PR DESCRIPTION
## 概要
- ShiftAnalyzer の主要メソッドに対するテストを追加
- 既存テストプロジェクトを xUnit + FluentAssertions へ移行
- ワークフローに `dotnet test` ステップを追加
- ShiftAnalyzer に null チェックと例外処理を実装

## テスト
- `dotnet test ShiftPlanner.sln --no-build` を実行しようとしたが `dotnet` コマンドが見つからず実行できず

------
https://chatgpt.com/codex/tasks/task_e_687d05399aa883338412ab7f9ead165b