### PR TITLE
fix: ThreadExceptionEventArgsの参照エラーを解消

### DIFF
--- a/ShiftPlanner/Program.cs
+++ b/ShiftPlanner/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using System.Windows.Forms;


### PR DESCRIPTION
## 概要
- `ThreadExceptionEventArgs` を利用するため `System.Threading` の using を追加
- グローバル例外ハンドラが正しくコンパイルされるよう修正

## テスト
- `dotnet build` （コマンドが見つからず実行不可）

------
https://chatgpt.com/codex/tasks/task_e_68b6431c698083338b3be36fa6636002